### PR TITLE
Hotfix for  #29 ml-api-adapter does not support calling call-back end-points that are provided with untrusted certificates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/ml-api-adapter",
-  "version": "3.3.0-snapshot",
+  "version": "3.3.1-snapshot",
   "description": "Convert from ML API to/from internal Central Services messaging format.",
   "license": "Apache-2.0",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "proxyquire": "1.7.10",
     "request": "^2.85.0",
     "rewire": "^4.0.1",
-    "sinon": "^5.0.10",
+    "sinon": "^6.1.5",
     "standard": "8.5.0",
     "supertest": "2.0.1",
     "tap-xunit": "1.4.0",

--- a/src/handlers/notification/callbacks.js
+++ b/src/handlers/notification/callbacks.js
@@ -31,7 +31,10 @@ const sendCallback = async (url, method, headers, message) => {
     url,
     method,
     // headers,
-    body: JSON.stringify(message)
+    body: JSON.stringify(message),
+    agentOptions: {
+      rejectUnauthorized: false
+    }
   }
 
   return new Promise((resolve, reject) => {

--- a/test/unit/handlers/notification/callbacks.test.js
+++ b/test/unit/handlers/notification/callbacks.test.js
@@ -68,12 +68,15 @@ Test('Callback Service tests', callbacksTest => {
       const url = Config.DFSP_URLS['dfsp2'].transfers
       const method = 'post'
       const headers = {}
+      const agentOptions = {
+        rejectUnauthorized: false
+      }
 
       const expected = 200
 
       const body = JSON.stringify(message)
 
-      request.withArgs({ url, method, body }).yields(null, { statusCode: 200 }, null)
+      request.withArgs({ url, method, body, agentOptions }).yields(null, { statusCode: 200 }, null)
 
       let result = await callback.sendCallback(url, method, headers, message)
       test.equal(result, expected)
@@ -101,11 +104,14 @@ Test('Callback Service tests', callbacksTest => {
       const url = Config.DFSP_URLS['dfsp2'].transfers
       const method = 'post'
       const headers = {}
+      const agentOptions = {
+        rejectUnauthorized: false
+      }
 
       const body = JSON.stringify(message)
       const error = new Error()
 
-      request.withArgs({ url, method, body }).yields(error, null, null)
+      request.withArgs({ url, method, body, agentOptions }).yields(error, null, null)
 
       try {
         await callback.sendCallback(url, method, headers, message)


### PR DESCRIPTION
https://github.com/mojaloop/ml-api-adapter/issues/29