### PR TITLE
HTTP Date Header Issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "inert": "5.1.0",
     "joi": "13.1.2",
     "joi-currency-code": "^1.2.1",
+    "joi-date-extensions": "^1.2.0",
     "json2csv": "3.11.5",
     "jsonwebtoken": "8.1.1",
     "knex": "0.14.2",

--- a/src/api/transfers/routes.js
+++ b/src/api/transfers/routes.js
@@ -22,7 +22,9 @@
 'use strict'
 
 const Handler = require('./handler')
-const Joi = require('joi-currency-code')(require('joi'))
+const BaseJoi = require('joi-currency-code')(require('joi'))
+const Extension = require('joi-date-extensions')
+const Joi = BaseJoi.extend(Extension)
 const tags = ['api', 'transfers']
 const transferState = [ 'RECEIVED', 'RESERVED', 'COMMITTED', 'ABORTED', 'SETTLED' ]
 
@@ -44,7 +46,7 @@ module.exports = [{
       headers: Joi.object({
         'content-type': Joi.string().required().valid('application/json'),
         'content-length': Joi.number().max(5242880),
-        'date': Joi.date().iso().required(),
+        'date': Joi.date().format('ddd, D MMM YYYY H:mm:ss [GMT]').required(),
         'x-forwarded-for': Joi.string().optional(),
         'fspiop-source': Joi.string().required(),
         'fspiop-destination': Joi.string().optional(),

--- a/src/api/transfers/routes.js
+++ b/src/api/transfers/routes.js
@@ -91,7 +91,7 @@ module.exports = [{
     validate: {
       headers: Joi.object({
         'content-type': Joi.string().required().valid('application/json'),
-        'date': Joi.date().iso().required(),
+        'date': Joi.date().format('ddd, D MMM YYYY H:mm:ss [GMT]').required(),
         'x-forwarded-for': Joi.string().optional(),
         'fspiop-source': Joi.string().required(),
         'fspiop-destination': Joi.string().optional(),

--- a/test/unit/api/transfers/routes.test.js
+++ b/test/unit/api/transfers/routes.test.js
@@ -26,7 +26,7 @@ const Test = require('tape')
 const Base = require('../../base')
 
 Test('return error if required fields are missing on prepare', async function (assert) {
-  let req = Base.buildRequest({ url: '/transfers', method: 'POST', payload: {}, headers: { 'date': '2018-04-26', 'fspiop-source': 'value', 'content-type': 'application/json' } })
+  let req = Base.buildRequest({ url: '/transfers', method: 'POST', payload: {}, headers: { 'date': 'Mon, 10 Sep 2018 20:22:01 GMT', 'fspiop-source': 'value', 'content-type': 'application/json' } })
   const server = await Base.setup()
   const res = await server.inject(req)
   Base.assertBadRequestError(assert, res, 'child "transferId" fails because [transferId is required]. child "payeeFsp" fails because [payeeFsp is required]. child "payerFsp" fails because [payerFsp is required]. child "amount" fails because [amount is required]. child "ilpPacket" fails because [ilpPacket is required]. child "condition" fails because [condition is required]. child "expiration" fails because [expiration is required]')
@@ -47,7 +47,7 @@ Test('return error if transferId is not a guid', async function (assert) {
   let req = Base.buildRequest({ url: '/transfers',
     method: 'POST',
     payload: { transferId: 'invalid transfer id' },
-    headers: { 'date': '2018-04-26', 'fspiop-source': 'value', 'content-type': 'application/json' }
+    headers: { 'date': 'Mon, 10 Sep 2018 20:22:01 GMT', 'fspiop-source': 'value', 'content-type': 'application/json' }
   })
   const server = await Base.setup()
   const res = await server.inject(req)
@@ -170,7 +170,45 @@ Test('return error if condition is not valid according to the pattern /^[A-Za-z0
   assert.end()
 })
 
-Test('return error if Date Header is not according to format in RFC7231 as per Mojaloop Spec', async function (assert) {
+Test('return error if Date Header is not according to format in RFC7231 as per Mojaloop Spec in POST /transfers', async function (assert) {
+  let req = Base.buildRequest({ url: '/transfers',
+    method: 'POST',
+    payload: {
+      transferId: 'b51ec534-ee48-4575-b6a9-ead2955b8069',
+      payeeFsp: '1234',
+      payerFsp: '5678',
+      amount: {
+        currency: 'USD',
+        amount: '123.45'
+      },
+      ilpPacket: 'AYIBgQAAAAAAAASwNGxldmVsb25lLmRmc3AxLm1lci45T2RTOF81MDdqUUZERmZlakgyOVc4bXFmNEpLMHlGTFGCAUBQU0svMS4wCk5vbmNlOiB1SXlweUYzY3pYSXBFdzVVc05TYWh3CkVuY3J5cHRpb246IG5vbmUKUGF5bWVudC1JZDogMTMyMzZhM2ItOGZhOC00MTYzLTg0NDctNGMzZWQzZGE5OGE3CgpDb250ZW50LUxlbmd0aDogMTM1CkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vanNvbgpTZW5kZXItSWRlbnRpZmllcjogOTI4MDYzOTEKCiJ7XCJmZWVcIjowLFwidHJhbnNmZXJDb2RlXCI6XCJpbnZvaWNlXCIsXCJkZWJpdE5hbWVcIjpcImFsaWNlIGNvb3BlclwiLFwiY3JlZGl0TmFtZVwiOlwibWVyIGNoYW50XCIsXCJkZWJpdElkZW50aWZpZXJcIjpcIjkyODA2MzkxXCJ9IgA',
+      condition: 'f5sqb7tBTWPd5Y8BDFdMm9BJR_MNI4isf8p8n4D5pHA',
+      expiration: '2016-05-24T08:38:08.699-04:00',
+      extensionList:
+      {
+        extension:
+        [
+          {
+            key: 'errorDescription',
+            value: 'This is a more detailed error description'
+          },
+          {
+            key: 'errorDescription',
+            value: 'This is a more detailed error description'
+          }
+        ]
+      }
+    },
+    headers: { 'date': '2018-04-26', 'fspiop-source': 'value', 'content-type': 'application/json' }
+  })
+  const server = await Base.setup()
+  const res = await server.inject(req)
+  Base.assertBadRequestError(assert, res, 'child "date" fails because [date must be a string with one of the following formats [ddd, D MMM YYYY H:mm:ss [GMT]]]')
+  await server.stop()
+  assert.end()
+})
+
+Test('return error if Date Header is not according to format in RFC7231 as per Mojaloop Spec in PUT /transfers', async function (assert) {
   let req = Base.buildRequest({ url: '/transfers',
     method: 'POST',
     payload: {

--- a/test/unit/api/transfers/routes.test.js
+++ b/test/unit/api/transfers/routes.test.js
@@ -85,7 +85,7 @@ Test('return error if amount is not a valid amount', async function (assert) {
         ]
       }
     },
-    headers: { 'date': '2018-04-26', 'fspiop-source': 'value', 'content-type': 'application/json' }
+    headers: { 'date': 'Mon, 10 Sep 2018 20:22:01 GMT', 'fspiop-source': 'value', 'content-type': 'application/json' }
   })
   const server = await Base.setup()
   const res = await server.inject(req)
@@ -123,7 +123,7 @@ Test('return error if currency is not a valid ISO 4217 currency code', async fun
         ]
       }
     },
-    headers: { 'date': '2018-04-26', 'fspiop-source': 'value', 'content-type': 'application/json' }
+    headers: { 'date': 'Mon, 10 Sep 2018 20:22:01 GMT', 'fspiop-source': 'value', 'content-type': 'application/json' }
   })
   const server = await Base.setup()
   const res = await server.inject(req)
@@ -161,11 +161,49 @@ Test('return error if condition is not valid according to the pattern /^[A-Za-z0
         ]
       }
     },
-    headers: { 'date': '2018-04-26', 'fspiop-source': 'value', 'content-type': 'application/json' }
+    headers: { 'date': 'Mon, 10 Sep 2018 20:22:01 GMT', 'fspiop-source': 'value', 'content-type': 'application/json' }
   })
   const server = await Base.setup()
   const res = await server.inject(req)
   Base.assertBadRequestError(assert, res, 'child "condition" fails because [condition with value "invalid condition" fails to match the required pattern: /^[A-Za-z0-9-_]{43}$/]')
+  await server.stop()
+  assert.end()
+})
+
+Test('return error if Date Header is not according to format in RFC7231 as per Mojaloop Spec', async function (assert) {
+  let req = Base.buildRequest({ url: '/transfers',
+    method: 'POST',
+    payload: {
+      transferId: 'b51ec534-ee48-4575-b6a9-ead2955b8069',
+      payeeFsp: '1234',
+      payerFsp: '5678',
+      amount: {
+        currency: 'USD',
+        amount: '123.45'
+      },
+      ilpPacket: 'AYIBgQAAAAAAAASwNGxldmVsb25lLmRmc3AxLm1lci45T2RTOF81MDdqUUZERmZlakgyOVc4bXFmNEpLMHlGTFGCAUBQU0svMS4wCk5vbmNlOiB1SXlweUYzY3pYSXBFdzVVc05TYWh3CkVuY3J5cHRpb246IG5vbmUKUGF5bWVudC1JZDogMTMyMzZhM2ItOGZhOC00MTYzLTg0NDctNGMzZWQzZGE5OGE3CgpDb250ZW50LUxlbmd0aDogMTM1CkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vanNvbgpTZW5kZXItSWRlbnRpZmllcjogOTI4MDYzOTEKCiJ7XCJmZWVcIjowLFwidHJhbnNmZXJDb2RlXCI6XCJpbnZvaWNlXCIsXCJkZWJpdE5hbWVcIjpcImFsaWNlIGNvb3BlclwiLFwiY3JlZGl0TmFtZVwiOlwibWVyIGNoYW50XCIsXCJkZWJpdElkZW50aWZpZXJcIjpcIjkyODA2MzkxXCJ9IgA',
+      condition: 'f5sqb7tBTWPd5Y8BDFdMm9BJR_MNI4isf8p8n4D5pHA',
+      expiration: '2016-05-24T08:38:08.699-04:00',
+      extensionList:
+      {
+        extension:
+        [
+          {
+            key: 'errorDescription',
+            value: 'This is a more detailed error description'
+          },
+          {
+            key: 'errorDescription',
+            value: 'This is a more detailed error description'
+          }
+        ]
+      }
+    },
+    headers: { 'date': '2018-04-26', 'fspiop-source': 'value', 'content-type': 'application/json' }
+  })
+  const server = await Base.setup()
+  const res = await server.inject(req)
+  Base.assertBadRequestError(assert, res, 'child "date" fails because [date must be a string with one of the following formats [ddd, D MMM YYYY H:mm:ss [GMT]]]')
   await server.stop()
   assert.end()
 })


### PR DESCRIPTION
The current code expects Date Header to be in ISO format. But as per the Mojaloop API spec, that format should be  RFC7231 compliant. This change to update Date Header format for POST /transfers and PUT /transfers/{ID} endpoints.