### PR TITLE
changed the joi validation to use regex instead of hard-coded values

### DIFF
--- a/src/api/transfers/routes.js
+++ b/src/api/transfers/routes.js
@@ -43,8 +43,8 @@ module.exports = [{
     },
     validate: {
       headers: Joi.object({
-        'accept': Joi.string().optional().valid('application/vnd.interoperability.transfers+json;version=1'),
-        'content-type': Joi.string().required().valid('application/vnd.interoperability.transfers+json;version=1.0'),
+        'accept': Joi.string().optional().regex(/application\/vnd.interoperability[.]/),
+        'content-type': Joi.string().required().regex(/application\/vnd.interoperability[.]/),
         'content-length': Joi.number().max(5242880),
         'date': Joi.date().format('ddd, D MMM YYYY H:mm:ss [GMT]').required(),
         'x-forwarded-for': Joi.string().optional(),
@@ -91,7 +91,7 @@ module.exports = [{
     },
     validate: {
       headers: Joi.object({
-        'content-type': Joi.string().required().valid('application/vnd.interoperability.transfers+json;version=1.0'),
+        'content-type': Joi.string().required().regex(/application\/vnd.interoperability[.]/),
         'date': Joi.date().format('ddd, D MMM YYYY H:mm:ss [GMT]').required(),
         'x-forwarded-for': Joi.string().optional(),
         'fspiop-source': Joi.string().required(),
@@ -133,8 +133,8 @@ module.exports = [{
     }, */
     validate: {
       headers: Joi.object({
-        'accept': Joi.string().optional().valid('application/vnd.interoperability.transfers+json;version=1'),
-        'content-type': Joi.string().required().valid('application/vnd.interoperability.transfers+json;version=1.0'),
+        'accept': Joi.string().optional().regex(/application\/vnd.interoperability[.]/),
+        'content-type': Joi.string().required().regex(/application\/vnd.interoperability[.]/),
         'date': Joi.date().format('ddd, D MMM YYYY H:mm:ss [GMT]').required(),
         'x-forwarded-for': Joi.string().optional(),
         'fspiop-source': Joi.string().required(),


### PR DESCRIPTION
### Changes for [Bug #516 ](https://github.com/mojaloop/project/issues/516)
Removed the hard-coded values for 'accept' and 'content-type' headers validation. Now it will use a regex

### Tests
```
=============================== Coverage summary ===============================
Statements   : 100% ( 522/522 )
Branches     : 100% ( 103/103 )
Functions    : 100% ( 55/55 )
Lines        : 100% ( 522/522 )
================================================================================

1..152
# tests 152
# pass  152

# ok

```