### PR TITLE
Hotfix for Duplicate Notification on POST /transfer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/ml-api-adapter",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/ml-api-adapter",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "Convert from ML API to/from internal Central Services messaging format.",
   "license": "Apache-2.0",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "test:coverage": "istanbul cover tape -- 'test/unit/**/*.test.js'",
     "test:coverage-check": "npm run test:coverage && istanbul check-coverage",
     "test:integration": "sh ./test/integration-runner.sh ./test/integration-runner.env",
+    "test:integration:server": "node test/integration/server/index.js",
     "test:functional": "sh ./test/functional-runner.sh ./test/functional-runner.env",
     "test:spec:test-only": "sh ./test/spec-runner.sh ./test/.env",
     "test:spec": "run-s docker:build test:spec:test-only",

--- a/src/domain/transfer/transformer.js
+++ b/src/domain/transfer/transformer.js
@@ -53,8 +53,15 @@ const transformHeaders = (headers, config) => {
       keys[k.toLowerCase()] = k
       return keys
     }, {})
+
   // Normalized headers
   var normalizedHeaders = {}
+
+  // check to see if FSPIOP-Destination header has been left out of the initial request. If so then add it.
+  if (!normalizedKeys.hasOwnProperty(ENUM.headers.FSPIOP.DESTINATION)) {
+    headers[ENUM.headers.FSPIOP.DESTINATION] = ''
+  }
+
   for (var headerKey in headers) {
     var headerValue = headers[headerKey]
     switch (headerKey.toLowerCase()) {

--- a/src/handlers/notification/callbacks.js
+++ b/src/handlers/notification/callbacks.js
@@ -27,6 +27,7 @@ const request = require('request')
 // const request = require('request-promise-native') // added to ensure that the request support async-await or promise natively
 const Transformer = require('../../domain/transfer/transformer')
 const Config = require('../../lib/config')
+const Enum = require('../../lib/enum')
 
 /**
  * @module src/handlers/notification/callbacks
@@ -48,6 +49,11 @@ const Config = require('../../lib/config')
 * @returns {Promise} Returns a promise which resolves the http status code on success or rejects the error on failure
 */
 const sendCallback = async (url, method, headers, message, cid, sourceFsp, destinationFsp) => {
+  // validate incoming request parameters are not null or undefined
+  if (!url || !method || !headers || !message || !cid || !sourceFsp || !destinationFsp) {
+    throw new Error(Enum.errorMessages.MISSINGFUNCTIONPARAMETERS)
+  }
+
   // Transform headers into Mojaloop v1.0 Specifications
   const transformedHeaders = Transformer.transformHeaders(headers, { httpMethod: method, sourceFsp: sourceFsp, destinationFsp })
 

--- a/src/handlers/notification/index.js
+++ b/src/handlers/notification/index.js
@@ -171,10 +171,10 @@ const processMessage = async (msg) => {
     }
 
     if (actionLower === ENUM.transferEventAction.PREPARE_DUPLICATE && statusLower === ENUM.messageStatus.SUCCESS) {
-      let callbackURLFrom = await Participant.getEndpoint(from, FSPIOP_CALLBACK_URL_TRANSFER_PUT, id)
+      let callbackURLTo = await Participant.getEndpoint(to, FSPIOP_CALLBACK_URL_TRANSFER_PUT, id)
       let methodFrom = ENUM.methods.FSPIOP_CALLBACK_URL_TRANSFER_PUT
-      Logger.debug(`Notification::processMessage - Callback.sendCallback(${callbackURLFrom}, ${methodFrom}, ${JSON.stringify(content.headers)}, ${JSON.stringify(content.payload)}, ${id}, ${from}, ${to})`)
-      return Callback.sendCallback(callbackURLFrom, methodFrom, content.headers, content.payload, id, from, to)
+      Logger.debug(`Notification::processMessage - Callback.sendCallback(${callbackURLTo}, ${methodFrom}, ${JSON.stringify(content.headers)}, ${JSON.stringify(content.payload)}, ${id}, ${from}, ${to})`)
+      return Callback.sendCallback(callbackURLTo, methodFrom, content.headers, content.payload, id, from, to)
     }
 
     if (actionLower === ENUM.transferEventAction.COMMIT && statusLower === ENUM.messageStatus.SUCCESS) {

--- a/src/lib/enum.js
+++ b/src/lib/enum.js
@@ -84,10 +84,15 @@ const messageStatus = {
   ERROR: 'error'
 }
 
+const errorMessages = {
+  MISSINGFUNCTIONPARAMETERS: 'Missing parameters for function'
+}
+
 module.exports = {
   headers,
   methods,
   transferEventType,
   transferEventAction,
-  messageStatus
+  messageStatus,
+  errorMessages
 }

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -1,0 +1,145 @@
+'use strict'
+
+const _ = require('lodash')
+const Config = require('./config')
+
+const omitNil = (object) => {
+  return _.omitBy(object, _.isNil)
+}
+
+const pick = (object, properties) => {
+  return _.pick(object, properties)
+}
+
+const assign = (target, source) => {
+  return Object.assign(target, source)
+}
+
+const merge = (target, source) => {
+  return Object.assign({}, target, source)
+}
+
+const mergeAndOmitNil = (target, source) => {
+  return omitNil(merge(target, source))
+}
+
+const formatAmount = (amount) => {
+  return Number(amount).toFixed(Config.AMOUNT.SCALE).toString()
+}
+
+const parseJson = (value) => {
+  if (typeof value !== 'string') {
+    return value
+  }
+
+  try {
+    return JSON.parse(value)
+  } catch (e) {
+    return value
+  }
+}
+
+const squish = (array) => {
+  return _.join(array, '|')
+}
+
+const expand = (value) => {
+  return (value) ? _.split(value, '|') : value
+}
+
+const filterUndefined = (fields) => {
+  for (let key in fields) {
+    if (fields[key] === undefined) {
+      delete fields[key]
+    }
+  }
+  return fields
+}
+
+/**
+ * Method to provide object clonning
+ *
+ * TODO:
+ *  Implement a better deep copy method
+ *
+ * @param value
+ * @returns {any}
+ */
+const clone = (value) => {
+  return JSON.parse(JSON.stringify(value))
+}
+
+/**
+ * Method to delete a field from an object, using case insensitive comparison
+ *
+ * TODO:
+ *  Implement a better delete method
+ *
+ * @param obj Object to have specified field deleted from
+ * @param key Key to be deleted from the target Object
+ */
+const deleteFieldByCaseInsensitiveKey = (obj, key) => {
+  for (var objKey in obj) {
+    switch (objKey.toLowerCase()) {
+      case (key.toLowerCase()):
+        delete obj[objKey]
+        break
+      default:
+        break
+    }
+  }
+}
+
+/**
+ * Method to get a value based on a field (key) from an object, using case insensitive comparison
+ *
+ * TODO:
+ *  Implement a better get method
+ *
+ * @param obj Object to have specified field searched for
+ * @param key Key to be compared using case insensitive comparison
+ * @returns value from case insensitive comparison search
+ */
+const getValueByCaseInsensitiveKey = (obj, key) => {
+  return obj[Object.keys(obj).find(objKey => objKey.toLowerCase() === key.toLowerCase())]
+}
+
+/**
+ * Method to set a value based on a field (key) from an object, using case insensitive comparison
+ *
+ * TODO:
+ *  Implement a better set method
+ *
+ * @param obj Object to have specified field searched for
+ * @param key Key to be compared using case insensitive comparison
+ * @param value Value to be assigned to the associated key map
+ * @returns value from case insensitive comparison search
+ */
+const setValueByCaseInsensitiveKey = (obj, key, value) => {
+  for (var objKey in obj) {
+    switch (objKey.toLowerCase()) {
+      case (key.toLowerCase()):
+        obj[objKey] = value
+        break
+      default:
+        break
+    }
+  }
+}
+
+module.exports = {
+  assign,
+  expand,
+  formatAmount,
+  merge,
+  mergeAndOmitNil,
+  omitNil,
+  parseJson,
+  pick,
+  squish,
+  filterUndefined,
+  clone,
+  deleteFieldByCaseInsensitiveKey,
+  getValueByCaseInsensitiveKey,
+  setValueByCaseInsensitiveKey
+}

--- a/test/integration/handlers/notification/index.test.js
+++ b/test/integration/handlers/notification/index.test.js
@@ -469,13 +469,13 @@ Test('Notification Handler', notificationHandlerTest => {
             condition: 'uU0nuZNNPgilLlLX2n2r-sSE7-N6U4DukIj3rOLvze1',
             expiration: '2018-08-24T21:31:00.534+01:00',
             ilpPacket: 'AQAAAAAAAABkEGcuZXdwMjEuaWQuODAwMjCCAhd7InRyYW5zYWN0aW9uSWQiOiJmODU0NzdkYi0xMzVkLTRlMDgtYThiNy0xMmIyMmQ4MmMwZDYiLCJxdW90ZUlkIjoiOWU2NGYzMjEtYzMyNC00ZDI0LTg5MmYtYzQ3ZWY0ZThkZTkxIiwicGF5ZWUiOnsicGFydHlJZEluZm8iOnsicGFydHlJZFR5cGUiOiJNU0lTRE4iLCJwYXJ0eUlkZW50aWZpZXIiOiIyNTYxMjM0NTYiLCJmc3BJZCI6IjIxIn19LCJwYXllciI6eyJwYXJ0eUlkSW5mbyI6eyJwYXJ0eUlkVHlwZSI6Ik1TSVNETiIsInBhcnR5SWRlbnRpZmllciI6IjI1NjIwMTAwMDAxIiwiZnNwSWQiOiIyMCJ9LCJwZXJzb25hbEluZm8iOnsiY29tcGxleE5hbWUiOnsiZmlyc3ROYW1lIjoiTWF0cyIsImxhc3ROYW1lIjoiSGFnbWFuIn0sImRhdGVPZkJpcnRoIjoiMTk4My0xMC0yNSJ9fSwiYW1vdW50Ijp7ImFtb3VudCI6IjEwMCIsImN1cnJlbmN5IjoiVVNEIn0sInRyYW5zYWN0aW9uVHlwZSI6eyJzY2VuYXJpbyI6IlRSQU5TRkVSIiwiaW5pdGlhdG9yIjoiUEFZRVIiLCJpbml0aWF0b3JUeXBlIjoiQ09OU1VNRVIifSwibm90ZSI6ImhlaiJ9',
-            payeeFsp: 'dfsp1',
-            payerFsp: 'dfsp2',
+            payeeFsp: 'dfsp2',
+            payerFsp: 'dfsp1',
             transferId: transferId
           }
         },
-        to: 'dfsp2',
-        from: 'dfsp1',
+        to: 'dfsp1',
+        from: 'switch',
         id: transferId,
         type: 'application/json'
       }
@@ -487,11 +487,11 @@ Test('Notification Handler', notificationHandlerTest => {
       await Kafka.Producer.produceMessage(messageProtocol, topicConfig, kafkaConfig)
 
       const operation = 'put'
-      let response = await getNotifications(messageProtocol.from, operation, transferId)
+      let response = await getNotifications(messageProtocol.to, operation, transferId)
       let currentAttempts = 0
       while (!response && currentAttempts < (timeoutAttempts * callbackWaitSeconds)) {
         sleep(callbackWaitSeconds)
-        response = await getNotifications(messageProtocol.from, operation, transferId)
+        response = await getNotifications(messageProtocol.to, operation, transferId)
         currentAttempts++
       }
       test.equal(response, JSON.stringify(messageProtocol.content.payload), 'Notification sent successfully to Payer')

--- a/test/integration/server/transfers/handler.js
+++ b/test/integration/server/transfers/handler.js
@@ -53,7 +53,7 @@ const endpoints = {
   ]
 }
 exports.receiveNotificationPost = async function (request, h) {
-  console.log('Received message')
+  console.log('Received receiveNotificationPost message')
   console.log('receiveNotification::headers(%s)', JSON.stringify(request.headers))
   console.log('receiveNotification::payload(%s)', JSON.stringify(request.payload))
   const transferId = request.payload.transferId
@@ -61,6 +61,7 @@ exports.receiveNotificationPost = async function (request, h) {
   const result = path.split('/')
   const operation = 'post'
   const fsp = result[1]
+  console.log('receiveNotificationPost::transferId(%s),fsp(%s),operation(%s)', transferId, fsp, operation)
   notifications[fsp] = {}
   notifications[fsp][operation] = {}
   notifications[fsp][operation][transferId] = request.payload
@@ -68,7 +69,7 @@ exports.receiveNotificationPost = async function (request, h) {
 }
 
 exports.receiveNotificationPut = async function (request, h) {
-  console.log('Received message')
+  console.log('Received receiveNotificationPut message')
   console.log('receiveNotification::headers(%s)', JSON.stringify(request.headers))
   console.log('receiveNotification::payload(%s)', JSON.stringify(request.payload))
   const transferId = request.params.transferId
@@ -77,6 +78,7 @@ exports.receiveNotificationPut = async function (request, h) {
   const operation = (path.includes('error') ? 'error' : 'put')
   const fsp = result[1]
   console.log('OPERATION:: ', operation)
+  console.log('receiveNotificationPut::transferId(%s),fsp(%s),operation(%s)', transferId, fsp, operation)
   notifications[fsp] = {}
   notifications[fsp][operation] = {}
   notifications[fsp][operation][transferId] = request.payload
@@ -91,6 +93,8 @@ exports.getNotification = async function (request, h) {
   let response = null
   if (notifications[fsp] && notifications[fsp][operation] && notifications[fsp][operation][transferId]) {
     response = notifications[fsp][operation][transferId]
+  // } else {
+  //   response = notifications
   }
   console.log('Response: %s', JSON.stringify(response))
   return h.response(response).code(200)

--- a/test/unit/handlers/notification/callbacks.test.js
+++ b/test/unit/handlers/notification/callbacks.test.js
@@ -29,9 +29,10 @@ const Sinon = require('sinon')
 const Logger = require('@mojaloop/central-services-shared').Logger
 const proxyquire = require('proxyquire')
 const Config = require('../../../../src/lib/config')
+const Enum = require('../../../../src/lib/enum')
 
-const sourceFps = 'sourceFsp'
-const destinationFps = 'sourceFsp'
+const sourceFsp = 'sourceFsp'
+const destinationFsp = 'destinationFsp'
 const cid = '1234567890'
 
 Test('Callback Service tests', callbacksTest => {
@@ -74,14 +75,17 @@ Test('Callback Service tests', callbacksTest => {
 
       const method = 'post'
 
-      const headers = {
+      let headers = {
         'Content-Length': 1234,
         'Random': 'string'
       }
+      headers[Enum.headers.FSPIOP.SOURCE] = sourceFsp
 
-      const expectedHeaders = {
+      let expectedHeaders = {
         'Random': 'string'
       }
+      expectedHeaders[Enum.headers.FSPIOP.DESTINATION] = destinationFsp
+      expectedHeaders[Enum.headers.FSPIOP.SOURCE] = sourceFsp
 
       const agentOptions = {
         rejectUnauthorized: Config.ENDPOINT_SECURITY_TLS.rejectUnauthorized
@@ -100,7 +104,7 @@ Test('Callback Service tests', callbacksTest => {
       request.withArgs(requestOptions).yieldsAsync(null, { statusCode: 200 }, null)
       let result = {}
       try {
-        result = await callback.sendCallback(url, method, headers, message, cid, sourceFps, destinationFps)
+        result = await callback.sendCallback(url, method, headers, message, cid, sourceFsp, destinationFsp)
         test.equal(result, expected)
         test.end()
       } catch (err) {
@@ -131,14 +135,208 @@ Test('Callback Service tests', callbacksTest => {
 
       const method = 'post'
 
-      const headers = {
+      let headers = {
         'Content-Length': 1234,
         'Random': 'string'
       }
+      headers[Enum.headers.FSPIOP.SOURCE] = sourceFsp
 
-      const expectedHeaders = {
+      let expectedHeaders = {
         'Random': 'string'
       }
+      expectedHeaders[Enum.headers.FSPIOP.DESTINATION] = destinationFsp
+      expectedHeaders[Enum.headers.FSPIOP.SOURCE] = sourceFsp
+
+      const agentOptions = {
+        rejectUnauthorized: Config.ENDPOINT_SECURITY_TLS.rejectUnauthorized
+      }
+
+      const requestOptions = {
+        url,
+        method,
+        headers: expectedHeaders,
+        body: JSON.stringify(message),
+        agentOptions
+      }
+
+      const error = new Error()
+
+      request.withArgs(requestOptions).yields(error, null, null)
+
+      try {
+        await callback.sendCallback(url, method, headers, message, cid, sourceFsp, destinationFsp)
+        test.fail('test failed without throwing an error')
+        test.end()
+      } catch (e) {
+        test.ok(e instanceof Error)
+        test.end()
+      }
+    })
+
+    sendCallbackTest.test('throw the error on error when no url is provided', async test => {
+      try {
+        await callback.sendCallback()
+        test.fail('test failed without throwing an error')
+        test.end()
+      } catch (e) {
+        test.ok(e instanceof Error)
+        test.equal(e.message, Enum.errorMessages.MISSINGFUNCTIONPARAMETERS)
+        test.end()
+      }
+    })
+
+    sendCallbackTest.test('throw the error on error when no method is provided', async test => {
+      const message = {
+        value: {
+          metadata: {
+            event: {
+              type: 'prepare',
+              action: 'prepare',
+              status: 'success'
+            }
+          },
+          content: {
+            headers: {},
+            payload: {}
+          },
+          to: 'dfsp2',
+          from: 'dfsp1'
+        }
+      }
+
+      const method = 'post'
+
+      let headers = {
+        'Content-Length': 1234,
+        'Random': 'string'
+      }
+      headers[Enum.headers.FSPIOP.SOURCE] = sourceFsp
+
+      let expectedHeaders = {
+        'Random': 'string'
+      }
+      expectedHeaders[Enum.headers.FSPIOP.DESTINATION] = destinationFsp
+      expectedHeaders[Enum.headers.FSPIOP.SOURCE] = sourceFsp
+
+      const agentOptions = {
+        rejectUnauthorized: Config.ENDPOINT_SECURITY_TLS.rejectUnauthorized
+      }
+
+      const requestOptions = {
+        url,
+        method,
+        headers: expectedHeaders,
+        body: JSON.stringify(message),
+        agentOptions
+      }
+
+      const error = new Error()
+
+      request.withArgs(requestOptions).yields(error, null, null)
+
+      try {
+        await callback.sendCallback(url, method)
+        test.fail('test failed without throwing an error')
+        test.end()
+      } catch (e) {
+        test.ok(e instanceof Error)
+        test.equal(e.message, Enum.errorMessages.MISSINGFUNCTIONPARAMETERS)
+        test.end()
+      }
+    })
+
+    sendCallbackTest.test('throw the error on error when no headers is provided', async test => {
+      const message = {
+        value: {
+          metadata: {
+            event: {
+              type: 'prepare',
+              action: 'prepare',
+              status: 'success'
+            }
+          },
+          content: {
+            headers: {},
+            payload: {}
+          },
+          to: 'dfsp2',
+          from: 'dfsp1'
+        }
+      }
+
+      const method = 'post'
+
+      let headers = {
+        'Content-Length': 1234,
+        'Random': 'string'
+      }
+      headers[Enum.headers.FSPIOP.SOURCE] = sourceFsp
+
+      let expectedHeaders = {
+        'Random': 'string'
+      }
+      expectedHeaders[Enum.headers.FSPIOP.DESTINATION] = destinationFsp
+      expectedHeaders[Enum.headers.FSPIOP.SOURCE] = sourceFsp
+
+      const agentOptions = {
+        rejectUnauthorized: Config.ENDPOINT_SECURITY_TLS.rejectUnauthorized
+      }
+
+      const requestOptions = {
+        url,
+        method,
+        headers: expectedHeaders,
+        body: JSON.stringify(message),
+        agentOptions
+      }
+
+      const error = new Error()
+
+      request.withArgs(requestOptions).yields(error, null, null)
+
+      try {
+        await callback.sendCallback(url, method, headers)
+        test.fail('test failed without throwing an error')
+        test.end()
+      } catch (e) {
+        test.ok(e instanceof Error)
+        test.equal(e.message, Enum.errorMessages.MISSINGFUNCTIONPARAMETERS)
+        test.end()
+      }
+    })
+
+    sendCallbackTest.test('throw the error on error when no cid is provided', async test => {
+      const message = {
+        value: {
+          metadata: {
+            event: {
+              type: 'prepare',
+              action: 'prepare',
+              status: 'success'
+            }
+          },
+          content: {
+            headers: {},
+            payload: {}
+          },
+          to: 'dfsp2',
+          from: 'dfsp1'
+        }
+      }
+
+      const method = 'post'
+
+      let headers = {
+        'Content-Length': 1234,
+        'Random': 'string'
+      }
+      headers[Enum.headers.FSPIOP.SOURCE] = sourceFsp
+
+      let expectedHeaders = {
+        'Random': 'string'
+      }
+      expectedHeaders[Enum.headers.FSPIOP.DESTINATION] = destinationFsp
+      expectedHeaders[Enum.headers.FSPIOP.SOURCE] = sourceFsp
 
       const agentOptions = {
         rejectUnauthorized: Config.ENDPOINT_SECURITY_TLS.rejectUnauthorized
@@ -158,8 +356,131 @@ Test('Callback Service tests', callbacksTest => {
 
       try {
         await callback.sendCallback(url, method, headers, message)
+        test.fail('test failed without throwing an error')
+        test.end()
       } catch (e) {
         test.ok(e instanceof Error)
+        test.equal(e.message, Enum.errorMessages.MISSINGFUNCTIONPARAMETERS)
+        test.end()
+      }
+    })
+
+    sendCallbackTest.test('throw the error on error when no sourceFsp is provided', async test => {
+      const message = {
+        value: {
+          metadata: {
+            event: {
+              type: 'prepare',
+              action: 'prepare',
+              status: 'success'
+            }
+          },
+          content: {
+            headers: {},
+            payload: {}
+          },
+          to: 'dfsp2',
+          from: 'dfsp1'
+        }
+      }
+
+      const method = 'post'
+
+      let headers = {
+        'Content-Length': 1234,
+        'Random': 'string'
+      }
+      headers[Enum.headers.FSPIOP.SOURCE] = sourceFsp
+
+      let expectedHeaders = {
+        'Random': 'string'
+      }
+      expectedHeaders[Enum.headers.FSPIOP.DESTINATION] = destinationFsp
+      expectedHeaders[Enum.headers.FSPIOP.SOURCE] = sourceFsp
+
+      const agentOptions = {
+        rejectUnauthorized: Config.ENDPOINT_SECURITY_TLS.rejectUnauthorized
+      }
+
+      const requestOptions = {
+        url,
+        method,
+        headers: expectedHeaders,
+        body: JSON.stringify(message),
+        agentOptions
+      }
+
+      const error = new Error()
+
+      request.withArgs(requestOptions).yields(error, null, null)
+
+      try {
+        await callback.sendCallback(url, method, headers, message, cid)
+        test.fail('test failed without throwing an error')
+        test.end()
+      } catch (e) {
+        test.ok(e instanceof Error)
+        test.equal(e.message, Enum.errorMessages.MISSINGFUNCTIONPARAMETERS)
+        test.end()
+      }
+    })
+
+    sendCallbackTest.test('throw the error on error when no destinationFsp is provided', async test => {
+      const message = {
+        value: {
+          metadata: {
+            event: {
+              type: 'prepare',
+              action: 'prepare',
+              status: 'success'
+            }
+          },
+          content: {
+            headers: {},
+            payload: {}
+          },
+          to: 'dfsp2',
+          from: 'dfsp1'
+        }
+      }
+
+      const method = 'post'
+
+      let headers = {
+        'Content-Length': 1234,
+        'Random': 'string'
+      }
+      headers[Enum.headers.FSPIOP.SOURCE] = sourceFsp
+
+      let expectedHeaders = {
+        'Random': 'string'
+      }
+      expectedHeaders[Enum.headers.FSPIOP.DESTINATION] = destinationFsp
+      expectedHeaders[Enum.headers.FSPIOP.SOURCE] = sourceFsp
+
+      const agentOptions = {
+        rejectUnauthorized: Config.ENDPOINT_SECURITY_TLS.rejectUnauthorized
+      }
+
+      const requestOptions = {
+        url,
+        method,
+        headers: expectedHeaders,
+        body: JSON.stringify(message),
+        agentOptions
+      }
+
+      const error = new Error()
+
+      request.withArgs(requestOptions).yields(error, null, null)
+
+      try {
+        await callback.sendCallback(url, method, headers, message, cid, sourceFsp)
+        test.fail('test failed without throwing an error')
+        test.end()
+      } catch (e) {
+        test.ok(e instanceof Error)
+        test.equal(e.message, Enum.errorMessages.MISSINGFUNCTIONPARAMETERS)
         test.end()
       }
     })

--- a/test/unit/lib/util.test.js
+++ b/test/unit/lib/util.test.js
@@ -1,0 +1,488 @@
+/*****
+ License
+ --------------
+ Copyright © 2017 Bill & Melinda Gates Foundation
+ The Mojaloop files are made available by the Bill & Melinda Gates Foundation under the Apache License, Version 2.0 (the "License") and you may not use these files except in compliance with the License. You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, the Mojaloop files are distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ Contributors
+ --------------
+ This is the official list of the Mojaloop project contributors for this file.
+ Names of the original copyright holders (individuals or organizations)
+ should be listed with a '*' in the first column. People who have
+ contributed from an organization can be listed under the organization
+ that actually holds the copyright for their contributions (see the
+ Gates Foundation organization for an example). Those individuals should have
+ their names indented and be marked with a '-'. Email address can be added
+ optionally within square brackets <email>.
+ * Gates Foundation
+ - Name Surname <name.surname@gatesfoundation.com>
+
+ * Georgi Georgiev <georgi.georgiev@modusbox.com>
+ * Rajiv Mothilal <rajiv.mothilal@modusbox.com>
+ * Miguel de Barros <miguel.debarros@modusbox.com>
+ --------------
+ ******/
+
+'use strict'
+
+const Test = require('tape')
+const Util = require('../../../src/lib/util')
+
+Test('util', utilTest => {
+  utilTest.test('formatAmount should', formatAmountTest => {
+    formatAmountTest.test('format integer', test => {
+      const value = parseInt('100')
+      test.equal(Util.formatAmount(value), '100.00')
+      test.end()
+    })
+
+    formatAmountTest.test('format decimal', test => {
+      const value = parseFloat('100.01')
+      test.equal(Util.formatAmount(value), '100.01')
+      test.end()
+    })
+
+    formatAmountTest.test('format string', test => {
+      const value = '5.1'
+      test.equal(Util.formatAmount(value), '5.10')
+      test.end()
+    })
+    formatAmountTest.end()
+  })
+
+  utilTest.test('parseJson should', parseJsonTest => {
+    parseJsonTest.test('return null if value null', test => {
+      const value = null
+      test.notOk(Util.parseJson(value))
+      test.end()
+    })
+    parseJsonTest.test('return value if value not string', test => {
+      const value = {}
+      test.equal(Util.parseJson(value), value)
+      test.end()
+    })
+
+    parseJsonTest.test('return value if number', test => {
+      const value = 1000
+      test.equal(Util.parseJson(value), value)
+      test.end()
+    })
+
+    parseJsonTest.test('return value if string that is not json', test => {
+      const value = 'some really long string'
+      test.equal(Util.parseJson(value), value)
+      test.end()
+    })
+
+    parseJsonTest.test('return object if value is json string', test => {
+      const obj = {
+        prop1: 'test',
+        prop2: {
+          'date_time': new Date().toDateString(),
+          'number': 1000
+        }
+      }
+      const value = JSON.stringify(obj)
+
+      const result = Util.parseJson(value)
+      test.notEqual(result, value)
+      test.deepEqual(result, obj)
+      test.end()
+    })
+    parseJsonTest.end()
+  })
+
+  utilTest.test('filterUndefined should', filterUndefinedTest => {
+    filterUndefinedTest.test('return map with undefined values stripped out', test => {
+      const undefinedMap = {}
+      const obj1 = {
+        prop1: 'test',
+        prop2: {
+          'date_time': new Date().toDateString(),
+          'number': 1000
+        },
+        prop3: undefinedMap.prop3,
+        prop4: null
+      }
+
+      const obj2 = {
+        prop1: 'test',
+        prop2: {
+          'date_time': new Date().toDateString(),
+          'number': 1000
+        },
+        prop4: null
+      }
+
+      const result = Util.filterUndefined(obj1)
+      test.deepEqual(result, obj2)
+      test.end()
+    })
+    filterUndefinedTest.end()
+  })
+
+  utilTest.test('omitNil should', omitNilTest => {
+    omitNilTest.test('return object with undefined values stripped out', test => {
+      const obj1 = {
+        prop1: 'test',
+        prop2: {
+          'date_time': new Date().toDateString(),
+          'number': 1000
+        },
+        prop3: null,
+        prop4: null
+      }
+
+      const expected = {
+        prop1: 'test',
+        prop2: {
+          'date_time': new Date().toDateString(),
+          'number': 1000
+        }
+      }
+
+      const result = Util.omitNil(obj1)
+      test.deepEqual(result, expected)
+      test.end()
+    })
+    omitNilTest.end()
+  })
+
+  utilTest.test('pick should', pickTest => {
+    pickTest.test('return object with only expected properties', test => {
+      const obj1 = {
+        prop1: 'test',
+        prop2: {
+          'date_time': new Date().toDateString(),
+          'number': 1000
+        },
+        prop3: null,
+        prop4: null
+      }
+
+      const properties = ['prop1', 'prop2']
+
+      const expected = {
+        prop1: 'test',
+        prop2: {
+          'date_time': new Date().toDateString(),
+          'number': 1000
+        }
+      }
+
+      const result = Util.pick(obj1, properties)
+      test.deepEqual(result, expected)
+      test.end()
+    })
+    pickTest.end()
+  })
+
+  utilTest.test('assign should', assignTest => {
+    assignTest.test('return target object with properties assigned from the source', test => {
+      const obj1 = {
+        prop1: 'test',
+        prop2: {
+          'date_time': new Date().toDateString(),
+          'number': 1000
+        },
+        prop5: 99
+      }
+
+      const obj2 = {
+        prop3: 'test2',
+        prop4: {
+          'number': 2000
+        },
+        prop5: 100
+      }
+
+      const expected = {
+        prop1: 'test',
+        prop2: {
+          'date_time': new Date().toDateString(),
+          'number': 1000
+        },
+        prop3: 'test2',
+        prop4: {
+          'number': 2000
+        },
+        prop5: 100
+      }
+
+      const result = Util.assign(obj1, obj2)
+      test.deepEqual(result, expected)
+      test.end()
+    })
+    assignTest.end()
+  })
+
+  utilTest.test('merge should', mergeTest => {
+    mergeTest.test('return target object with properties merged from the source', test => {
+      const obj1 = {
+        prop1: 'test',
+        prop2: {
+          'date_time': new Date().toDateString(),
+          'number': 1000
+        },
+        prop5: 99
+      }
+
+      const obj2 = {
+        prop3: 'test2',
+        prop4: {
+          'number': 2000
+        },
+        prop5: 100
+      }
+
+      const expected = {
+        prop1: 'test',
+        prop2: {
+          'date_time': new Date().toDateString(),
+          'number': 1000
+        },
+        prop3: 'test2',
+        prop4: {
+          'number': 2000
+        },
+        prop5: 100
+      }
+
+      const result = Util.merge(obj1, obj2)
+      test.deepEqual(result, expected)
+      test.end()
+    })
+    mergeTest.end()
+  })
+
+  utilTest.test('mergeAndOmitNil should', mergeAndOmitNilTest => {
+    mergeAndOmitNilTest.test('return target object with properties merged from the source omitting undefined properties', test => {
+      const obj1 = {
+        prop1: 'test',
+        prop2: {
+          'date_time': new Date().toDateString(),
+          'number': 1000
+        },
+        prop5: 99,
+        prop6: null
+      }
+
+      const obj2 = {
+        prop3: 'test2',
+        prop4: {
+          'number': 2000
+        },
+        prop5: 100,
+        prop7: null
+      }
+
+      const expected = {
+        prop1: 'test',
+        prop2: {
+          'date_time': new Date().toDateString(),
+          'number': 1000
+        },
+        prop3: 'test2',
+        prop4: {
+          'number': 2000
+        },
+        prop5: 100
+      }
+
+      const result = Util.mergeAndOmitNil(obj1, obj2)
+      test.deepEqual(result, expected)
+      test.end()
+    })
+    mergeAndOmitNilTest.end()
+  })
+
+  utilTest.test('squish should', squishTest => {
+    squishTest.test('return a string by joining elements of an array', test => {
+      const array1 = [1, 2, 3, 4, 5]
+
+      const expected = '1|2|3|4|5'
+
+      const result = Util.squish(array1)
+      test.equal(result, expected)
+      test.end()
+    })
+    squishTest.end()
+  })
+
+  utilTest.test('expand should', expandTest => {
+    expandTest.test('return an array by splitting a string', test => {
+      const expected = ['1', '2', '3', '4', '5']
+
+      const string = '1|2|3|4|5'
+
+      const result = Util.expand(string)
+      test.deepEqual(result, expected)
+      test.end()
+    })
+
+    expandTest.test('return null if null is passed', test => {
+      const expected = null
+
+      const string = null
+
+      const result = Util.expand(string)
+      test.deepEqual(result, expected)
+      test.end()
+    })
+    expandTest.end()
+  })
+
+  utilTest.test('clone should', cloneTest => {
+    cloneTest.test('return a copied object with the same properties', test => {
+      const obj1 = {
+        prop1: 'test',
+        prop2: {
+          'date_time': new Date().toDateString(),
+          'number': 1000
+        },
+        prop3: null,
+        prop4: null
+      }
+
+      const expected = JSON.parse(JSON.stringify(obj1))
+
+      const result = Util.clone(obj1)
+
+      test.deepEqual(result, expected)
+      test.end()
+    })
+    cloneTest.end()
+  })
+
+  utilTest.test('deleteFieldByCaseInsensitiveKey should', deleteFieldByCaseInsensitiveKeyTest => {
+    deleteFieldByCaseInsensitiveKeyTest.test('delete a property from a specific object regardless of case sensitivity', test => {
+      const obj1 = {
+        prop1: 'test',
+        prop2: {
+          'date_time': new Date().toDateString(),
+          'number': 1000
+        },
+        prop3: null,
+        prop4: null
+      }
+
+      const expected = JSON.parse(JSON.stringify(obj1))
+
+      delete expected.prop3
+
+      Util.deleteFieldByCaseInsensitiveKey(obj1, 'ProP3')
+
+      test.deepEqual(obj1, expected)
+      test.end()
+    })
+
+    deleteFieldByCaseInsensitiveKeyTest.test('delete a property from a specific object regardless of case sensitivity that does not exist', test => {
+      const obj1 = {
+        prop1: 'test',
+        prop2: {
+          'date_time': new Date().toDateString(),
+          'number': 1000
+        },
+        prop3: null,
+        prop4: null
+      }
+
+      const expected = JSON.parse(JSON.stringify(obj1))
+
+      Util.deleteFieldByCaseInsensitiveKey(obj1, 'does not exist')
+
+      test.deepEqual(obj1, expected)
+      test.end()
+    })
+
+    deleteFieldByCaseInsensitiveKeyTest.end()
+  })
+
+  utilTest.test('getValueByCaseInsensitiveKey should', getValueByCaseInsensitiveKeyTest => {
+    getValueByCaseInsensitiveKeyTest.test('return a value from an object regardless of key case sensitivity', test => {
+      const obj1 = {
+        prop1: 'test',
+        prop2: {
+          'date_time': new Date().toDateString(),
+          'number': 1000
+        },
+        prop3: null,
+        prop4: null
+      }
+
+      const expected = obj1.prop1
+
+      const result = Util.getValueByCaseInsensitiveKey(obj1, 'ProP1')
+
+      test.deepEqual(result, expected)
+      test.end()
+    })
+
+    getValueByCaseInsensitiveKeyTest.test('return no value from an object regardless of key case sensitivity if it does not exist', test => {
+      const obj1 = {
+        prop1: 'test',
+        prop2: {
+          'date_time': new Date().toDateString(),
+          'number': 1000
+        },
+        prop3: null,
+        prop4: null
+      }
+
+      const expected = undefined
+
+      const result = Util.getValueByCaseInsensitiveKey(obj1, 'does not exist')
+
+      test.deepEqual(result, expected)
+      test.end()
+    })
+
+    getValueByCaseInsensitiveKeyTest.end()
+  })
+
+  utilTest.test('setValueByCaseInsensitiveKey should', setValueByCaseInsensitiveKeyTest => {
+    setValueByCaseInsensitiveKeyTest.test('set a value from an object regardless of key case sensitivity', test => {
+      const obj1 = {
+        prop1: 'test',
+        prop2: {
+          'date_time': new Date().toDateString(),
+          'number': 1000
+        },
+        prop3: null,
+        prop4: null
+      }
+
+      const expected = Util.clone(obj1)
+      expected.prop1 = 'value'
+
+      Util.setValueByCaseInsensitiveKey(obj1, 'ProP1', 'value')
+
+      test.deepEqual(obj1, expected)
+      test.end()
+    })
+
+    setValueByCaseInsensitiveKeyTest.test('not set a value from an object regardless of key case sensitivity if it does not exist', test => {
+      const obj1 = {
+        prop1: 'test',
+        prop2: {
+          'date_time': new Date().toDateString(),
+          'number': 1000
+        },
+        prop3: null,
+        prop4: null
+      }
+
+      const expected = Util.clone(obj1)
+
+      Util.setValueByCaseInsensitiveKey(obj1, 'does not exist', 'value')
+
+      test.deepEqual(obj1, expected)
+      test.end()
+    })
+
+    setValueByCaseInsensitiveKeyTest.end()
+  })
+
+  utilTest.end()
+})


### PR DESCRIPTION
Hotfix for the following changes:
- POST /transfer duplicate functionality will now correctly send a callback to the correct destination & source based on the central-ledger logic changes
- GET /transfers now returns an FSPIOP-Destination header even when not included in the original request.