### PR TITLE
Feature/801 replace npm license scan with mojaloop/license-scanner

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,11 @@ defaults_awsCliDependencies: &defaults_awsCliDependencies |
     pip install --upgrade awscli==1.14.5 s3cmd==2.0.1 python-magic
     apk -v --purge del py-pip
 
+defaults_license_checker: &defaults_license_checker |
+    git clone https://github.com/mojaloop/license-scanner /tmp/license-scanner
+    cd /tmp/license-scanner
+    make build default-files
+
 defaults_build_docker_login: &defaults_build_docker_login
   name: Login to Docker Hub
   command: |
@@ -287,23 +292,21 @@ jobs:
       - run:
           name: Install general dependencies
           command: *defaults_Dependencies
+      - run:
+          name: Install license_checker
+          command: *defaults_license_checker
       - checkout
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
-      # TODO: audit the licenses here
       - run:
-          name: Create dir for test results
-          command: mkdir -p ./audit/results
+          name: Set up License Checker
+          command: cd /tmp/license-scanner && make set-up
       - run:
-          # This shouldn't ever fail
-          name: List all found licenses
-          command: npm run license:list -- --out ./audit/results/licenseResults.csv
-      - run:
-          name: Check for disallowed licenses
-          command: npm run license:check
+          name: Run the license-scanner
+          command: cd /tmp/license-scanner && pathToRepo=$CIRCLE_WORKING_DIRECTORY make run
       - store_artifacts:
-          path: ./audit/results
-          prefix: audit
+          path: /tmp/license-scanner/results
+          prefix: licenses
 
   build-snapshot:
     machine: true

--- a/.licensebanned
+++ b/.licensebanned
@@ -1,7 +1,0 @@
-# A list of licenses that we won't allow in the repo
-# will ban the MIT licence from being allowed in this repo
-
-UNKNOWN
-GPL-1.0
-GPL-2.0
-GPL-3.0

--- a/.licenseignore
+++ b/.licenseignore
@@ -1,7 +1,0 @@
-# A list of packages that we have manually audited and are ok with the license
-#e.g.
-#z-schema@3.25.1
-# will ignore z-schema@3.25.1 in the license check
-
-#taffydb evaluates as unknown, but is actually MIT licensed
-taffydb@2.6.2


### PR DESCRIPTION
Part of: https://github.com/mojaloop/project/issues/801

Instead of installing and using npm's license checker, and storing `.licenseignore` and `.licensebanned` files locally, we use the newly minted `mojaloop/license-scanner` tool in CI mode, which allows us to globally manage licenses to check for and packages to ignore.