### PR TITLE
Removed broker and central service health checks in API mode only

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/ml-api-adapter",
-  "version": "7.1.1",
+  "version": "7.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/ml-api-adapter",
-  "version": "7.1.1",
+  "version": "7.1.2",
   "description": "Convert from ML API to/from internal Central Services messaging format",
   "license": "Apache-2.0",
   "private": true,

--- a/src/api/metadata/handler.js
+++ b/src/api/metadata/handler.js
@@ -1,19 +1,56 @@
+/*****
+ License
+ --------------
+ Copyright © 2017 Bill & Melinda Gates Foundation
+ The Mojaloop files are made available by the Bill & Melinda Gates Foundation under the Apache License, Version 2.0 (the "License") and you may not use these files except in compliance with the License. You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, the Mojaloop files are distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ Contributors
+ --------------
+ This is the official list of the Mojaloop project contributors for this file.
+ Names of the original copyright holders (individuals or organizations)
+ should be listed with a '*' in the first column. People who have
+ contributed from an organization can be listed under the organization
+ that actually holds the copyright for their contributions (see the
+ Gates Foundation organization for an example). Those individuals should have
+ their names indented and be marked with a '-'. Email address can be added
+ optionally within square brackets <email>.
+ * Gates Foundation
+ - Name Surname <name.surname@gatesfoundation.com>
+
+ * VesselsTech
+ - Lewis Daly <lewis@vesselstech.com>
+
+ * ModusBox
+ - Miguel de Barros <miguel.debarros@modusbox.com>
+
+ --------------
+ ******/
+
 'use strict'
 
 const HealthCheck = require('@mojaloop/central-services-shared').HealthCheck.HealthCheck
 const { defaultHealthHandler } = require('@mojaloop/central-services-health')
-
 const packageJson = require('../../../package.json')
 const Config = require('../../lib/config')
+
 const {
   getSubServiceHealthBroker,
   getSubServiceHealthCentralLedger
 } = require('../../lib/healthCheck/subServiceHealth.js')
 
-const healthCheck = new HealthCheck(packageJson, [
-  getSubServiceHealthBroker,
-  getSubServiceHealthCentralLedger
-])
+let healthCheck
+
+if (!Config.HANDLERS_DISABLED) {
+  healthCheck = new HealthCheck(packageJson, [
+    getSubServiceHealthBroker,
+    getSubServiceHealthCentralLedger
+  ])
+} else {
+  // TODO: Include getSubServiceHealthBroker once 'getMetadata' enhancement has been added to the central-services-stream Producer
+  healthCheck = new HealthCheck(packageJson, [
+  ])
+}
 
 /**
  * @module src/api/metadata/handler

--- a/src/lib/healthCheck/subServiceHealth.js
+++ b/src/lib/healthCheck/subServiceHealth.js
@@ -38,6 +38,7 @@ const axios = require('axios')
  * @returns Promise<SubServiceHealth> The SubService health object for the broker
  */
 const getSubServiceHealthBroker = async () => {
+  // TODO: Include use-case when running in API mode only (handlers.disabled=true) once 'getMetadata' enhancement has been added to the central-services-stream Producer.
   let status = statusEnum.OK
   try {
     await Notification.isConnected()


### PR DESCRIPTION
Updated health-endpoints to not check for broker or central-ledger back-end services when service runs in API mode only (handlers.enabled = false).
