### PR TITLE
Fix/869 duplicate response header validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/ml-api-adapter",
-  "version": "7.1.4",
+  "version": "7.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2917,8 +2917,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2939,14 +2938,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2961,20 +2958,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3091,8 +3085,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3104,7 +3097,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3119,7 +3111,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3127,14 +3118,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3153,7 +3142,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3234,8 +3222,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3247,7 +3234,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3333,8 +3319,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3370,7 +3355,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3390,7 +3374,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3434,14 +3417,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/ml-api-adapter",
-  "version": "7.1.4",
+  "version": "7.2.0",
   "description": "Convert from ML API to/from internal Central Services messaging format",
   "license": "Apache-2.0",
   "private": true,

--- a/src/domain/transfer/index.js
+++ b/src/domain/transfer/index.js
@@ -46,6 +46,7 @@ const GET = 'get'
 *
 * @param {object} headers - the http header from the request
 * @param {object} message - the transfer prepare message
+* @param {object} dataUri - base64 encoded string
 *
 * @returns {boolean} Returns true on successful publishing of message to kafka, throws error on falires
 */
@@ -59,6 +60,10 @@ const prepare = async (headers, message, dataUri) => {
       from: message.payerFsp,
       type: 'application/json',
       content: {
+        // TODO: will message.transferId always exist?
+        uriParams: {
+          id: message.transferId
+        },
         headers: headers,
         payload: dataUri
       },

--- a/src/domain/transfer/transformer.js
+++ b/src/domain/transfer/transformer.js
@@ -131,7 +131,7 @@ const transformHeaders = (headers, config) => {
     // Check to see if we find a regex match the source header containing the switch name.
     // If so we remove the signature added by default.
     delete normalizedHeaders[ENUM.headers.FSPIOP.SIGNATURE]
-    // Aslo remove FSPIOP-URI and make FSPIOP-HTTP-Method ALL-CAPS #737
+    // Also remove FSPIOP-URI and make FSPIOP-HTTP-Method ALL-CAPS #737
     delete normalizedHeaders[ENUM.headers.FSPIOP.URI]
   }
 

--- a/test/unit/domain/transfer/index.test.js
+++ b/test/unit/domain/transfer/index.test.js
@@ -437,5 +437,131 @@ Test('Transfer Service tests', serviceTest => {
     })
     transferErrorTest.end()
   })
+
+  serviceTest.test('message format tests', formatTest => {
+    /* Test Data */
+    const transferId = 'b51ec534-ee48-4575-b6a9-ead2955b8069'
+    const message = {
+      transferId,
+      payeeFsp: '1234',
+      payerFsp: '5678',
+      amount: {
+        currency: 'USD',
+        amount: 123.45
+      },
+      ilpPacket: 'AYIBgQAAAAAAAASwNGxldmVsb25lLmRmc3AxLm1lci45T2RTOF81MDdqUUZERmZlakgyOVc4bXFmNEpLMHlGTFGCAUBQU0svMS4wCk5vbmNlOiB1SXlweUYzY3pYSXBFdzVVc05TYWh3CkVuY3J5cHRpb246IG5vbmUKUGF5bWVudC1JZDogMTMyMzZhM2ItOGZhOC00MTYzLTg0NDctNGMzZWQzZGE5OGE3CgpDb250ZW50LUxlbmd0aDogMTM1CkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vanNvbgpTZW5kZXItSWRlbnRpZmllcjogOTI4MDYzOTEKCiJ7XCJmZWVcIjowLFwidHJhbnNmZXJDb2RlXCI6XCJpbnZvaWNlXCIsXCJkZWJpdE5hbWVcIjpcImFsaWNlIGNvb3BlclwiLFwiY3JlZGl0TmFtZVwiOlwibWVyIGNoYW50XCIsXCJkZWJpdElkZW50aWZpZXJcIjpcIjkyODA2MzkxXCJ9IgA',
+      condition: 'f5sqb7tBTWPd5Y8BDFdMm9BJR_MNI4isf8p8n4D5pHA',
+      expiration: '2016-05-24T08:38:08.699-04:00',
+      extensionList:
+      {
+        extension:
+          [
+            {
+              key: 'errorDescription',
+              value: 'This is a more detailed error description'
+            },
+            {
+              key: 'errorDescription',
+              value: 'This is a more detailed error description'
+            }
+          ]
+      }
+    }
+    const headers = {}
+    const dataUri = ''
+
+    formatTest.test('prepare should call `produceMessage` with the correct messageProtocol format', async test => {
+      // Arrange
+      let resultMessageProtocol = {}
+      // stub and unwrap the message sent to `Kafka.Producer.produceMessage`
+      Kafka.Producer.produceMessage = (messageProtocol, topicConfig, kafkaConfig) => {
+        resultMessageProtocol = messageProtocol
+      }
+
+      const expectedMessageProtocol = {
+        to: message.payeeFsp,
+        from: message.payerFsp,
+        type: 'application/json',
+        content: {
+          uriParams: {
+            id: message.transferId
+          },
+          headers,
+          payload: dataUri
+        },
+        metadata: {
+          event: {
+            type: 'prepare',
+            action: 'prepare',
+            state: {
+              status: 'success',
+              code: 0
+            }
+          }
+        }
+      }
+
+      // Act
+      await Service.prepare(headers, message, dataUri)
+
+      // Delete non-deterministic fields
+      delete resultMessageProtocol.id
+      delete resultMessageProtocol.metadata.event.id
+      delete resultMessageProtocol.metadata.event.createdAt
+
+      // Assert
+      test.deepEqual(resultMessageProtocol, expectedMessageProtocol, 'messageProtocols should match')
+      test.end()
+    })
+
+    // TODO: I'm not sure this is a valid case
+    formatTest.test('prepare should not fail if message.transferId is undefined', async test => {
+      // Arrange
+      let resultMessageProtocol = {}
+      delete message.transferId
+      // stub and unwrap the message sent to `Kafka.Producer.produceMessage`
+      Kafka.Producer.produceMessage = (messageProtocol, topicConfig, kafkaConfig) => {
+        resultMessageProtocol = messageProtocol
+      }
+
+      const expectedMessageProtocol = {
+        to: message.payeeFsp,
+        from: message.payerFsp,
+        type: 'application/json',
+        content: {
+          uriParams: {
+            id: undefined
+          },
+          headers,
+          payload: dataUri
+        },
+        metadata: {
+          event: {
+            type: 'prepare',
+            action: 'prepare',
+            state: {
+              status: 'success',
+              code: 0
+            }
+          }
+        }
+      }
+
+      // Act
+      await Service.prepare(headers, message, dataUri)
+
+      // Delete non-deterministic fields
+      delete resultMessageProtocol.id
+      delete resultMessageProtocol.metadata.event.id
+      delete resultMessageProtocol.metadata.event.createdAt
+
+      // Assert
+      test.deepEqual(resultMessageProtocol, expectedMessageProtocol, 'messageProtocols should match')
+      test.end()
+    })
+
+    formatTest.end()
+  })
+
   serviceTest.end()
 })


### PR DESCRIPTION
Fix an issue in the message creation in `src/domain/transfer/index.js`, which was causing downstream errors when checking for duplicate transfers.

Added new unit tests to validate the message.