### PR TITLE
Fix/899 integration runner hardcoded ENDPOINT_URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/ml-api-adapter",
-  "version": "7.3.0",
+  "version": "7.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3289,8 +3289,7 @@
           "version": "2.1.1",
           "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3314,15 +3313,13 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3339,22 +3336,19 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3485,8 +3479,7 @@
           "version": "2.0.3",
           "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3500,7 +3493,6 @@
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3517,7 +3509,6 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3526,15 +3517,13 @@
           "version": "0.0.8",
           "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": false,
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3555,7 +3544,6 @@
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3644,8 +3632,7 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3659,7 +3646,6 @@
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3755,8 +3741,7 @@
           "version": "5.1.2",
           "resolved": false,
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3798,7 +3783,6 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3820,7 +3804,6 @@
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3869,15 +3852,13 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": false,
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/ml-api-adapter",
-  "version": "7.3.0",
+  "version": "7.3.1",
   "description": "Convert from ML API to/from internal Central Services messaging format",
   "license": "Apache-2.0",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test:unit": "tape 'test/unit/**/*.test.js'",
     "test:int1": "ENDPOINT_HOST=http://localhost:4545 node test/integration/server/index.js",
     "test:int2": "MLAPI_ENDPOINT_SOURCE_URL=http://localhost:4545/participants/{{fsp}}/endpoints node src/api/index.js",
-    "test:int": "ENDPOINT_URL=http://localhost:4545/notification tape 'test/integration/**/*.test.js'",
+    "test:int": "tape 'test/integration/**/*.test.js'",
     "test:all": "run-s test test:integration test:functional test:spec",
     "test:xunit": "tape 'test/unit/**/*.test.js' | tap-xunit",
     "test:coverage": "nyc --reporter=lcov --reporter=text-summary tapes -- 'test/unit/**/**.test.js'",

--- a/test/integration-runner.env
+++ b/test/integration-runner.env
@@ -22,6 +22,7 @@ APP_PORT=${APP_PORT:-"3000"}
 APP_CMD=${APP_CMD:-"node src/api/index.js"}
 APP_TEST_HOST=${APP_TEST_HOST:-"ml-api-adapter-integration-2181"}
 APP_DIR_TEST_RESULTS=${APP_DIR_TEST_RESULTS:-"test/results"}
-TEST_CMD=${TEST_CMD:-"tape 'test/integration/**/*.test.js' | tap-xunit > ./test/results/tape-integration.xml "}
+# TEST_CMD=${TEST_CMD:-"tape 'test/integration/**/*.test.js' | tap-xunit > ./test/results/tape-integration.xml "}
+TEST_CMD=${TEST_CMD:-"npm run test:int --silent | tap-xunit > ./test/results/tape-integration.xml "}
 
 

--- a/test/integration-runner.env
+++ b/test/integration-runner.env
@@ -22,7 +22,6 @@ APP_PORT=${APP_PORT:-"3000"}
 APP_CMD=${APP_CMD:-"node src/api/index.js"}
 APP_TEST_HOST=${APP_TEST_HOST:-"ml-api-adapter-integration-2181"}
 APP_DIR_TEST_RESULTS=${APP_DIR_TEST_RESULTS:-"test/results"}
-# TEST_CMD=${TEST_CMD:-"tape 'test/integration/**/*.test.js' | tap-xunit > ./test/results/tape-integration.xml "}
 TEST_CMD=${TEST_CMD:-"npm run test:int --silent | tap-xunit > ./test/results/tape-integration.xml "}
 
 


### PR DESCRIPTION
This is a minor fix to bring the `npm run test:int` command more in line with the other repos, and remove the unneeded hardcoding of the `ENDPOINT_URL` environment variable in `package.json`