### PR TITLE
feat(mojaloop/#2704): core-services support for non-breaking backward api compatibility

### DIFF
--- a/audit-resolve.json
+++ b/audit-resolve.json
@@ -176,6 +176,11 @@
       "decision": "ignore",
       "madeAt": 1645104323030,
       "expiresAt": 1647696313138
+    },
+    "1007050|@mojaloop/central-services-shared>widdershins>urijs": {
+      "decision": "ignore",
+      "madeAt": 1646235001499,
+      "expiresAt": 1648826992822
     }
   },
   "rules": {},

--- a/audit-resolve.json
+++ b/audit-resolve.json
@@ -181,6 +181,11 @@
       "decision": "ignore",
       "madeAt": 1646235001499,
       "expiresAt": 1648826992822
+    },
+    "1007017|00unidentified>widdershins>swagger2openapi>oas-validator>ajv": {
+      "decision": "ignore",
+      "madeAt": 1646300189108,
+      "expiresAt": 1648892183526
     }
   },
   "rules": {},

--- a/config/default.json
+++ b/config/default.json
@@ -8,11 +8,18 @@
     "generateTimeout": 30000
   },
   "PROTOCOL_VERSIONS": {
-    "CONTENT": "1.1",
+    "CONTENT": {
+      "DEFAULT": "1.1",
+      "VALIDATELIST": [
+        "1.1",
+        "1.0"
+      ]
+    },
     "ACCEPT": {
       "DEFAULT": "1",
       "VALIDATELIST": [
         "1",
+        "1.0",
         "1.1"
       ]
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -289,9 +289,9 @@
       "dev": true
     },
     "@babel/runtime": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.0.tgz",
-      "integrity": "sha512-etcO/ohMNaNA2UBdaXBBSX/3aEzFMRrVfaPv8Ptc0k+cWpWW0QFiGZ2XnVqQZI1Cf734LbPGmqBKWESfW4x/dQ==",
+      "version": "7.17.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
+      "integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -1106,12 +1106,12 @@
       }
     },
     "@mojaloop/central-services-shared": {
-      "version": "15.3.0",
-      "resolved": "git+https://github.com/mojaloop/central-services-shared.git#f7c6972022299cc0408ddd75d62acac9192f4285",
+      "version": "git+ssh://git@github.com/mdebarros/central-services-shared.git#151a408e8001b3a301f37888fbc28f1fdfea9e74",
+      "from": "git+ssh://git@github.com/mdebarros/central-services-shared.git#feat/#2704-core-services-support-for-non-breaking-backward-api-compatibility",
       "requires": {
         "@hapi/catbox": "11.1.1",
         "@hapi/catbox-memory": "5.0.1",
-        "axios": "0.25.0",
+        "axios": "0.26.0",
         "clone": "2.1.2",
         "dotenv": "16.0.0",
         "env-var": "7.1.1",
@@ -1119,28 +1119,13 @@
         "immutable": "4.0.0",
         "lodash": "4.17.21",
         "mustache": "4.2.0",
-        "openapi-backend": "5.2.0",
-        "raw-body": "2.4.2",
+        "openapi-backend": "5.2.1",
+        "raw-body": "2.5.1",
         "rc": "1.2.8",
         "shins": "2.6.0",
         "uuid4": "2.0.2",
         "widdershins": "4.0.1",
         "yaml": "1.10.2"
-      },
-      "dependencies": {
-        "axios": {
-          "version": "0.25.0",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
-          "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
-          "requires": {
-            "follow-redirects": "^1.14.7"
-          }
-        },
-        "follow-redirects": {
-          "version": "1.14.8",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
-          "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA=="
-        }
       }
     },
     "@mojaloop/central-services-stream": {
@@ -1698,11 +1683,6 @@
           "requires": {
             "mime-db": "1.51.0"
           }
-        },
-        "negotiator": {
-          "version": "0.6.3",
-          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-          "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
         }
       }
     },
@@ -2220,26 +2200,54 @@
       "integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg=="
     },
     "body-parser": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.1.tgz",
-      "integrity": "sha512-8ljfQi5eBk8EJfECMrgqNGWPEY5jWP+1IzkzkGdFFEwFQZZyaZ21UqdaHktgiMlH0xLHqIFtE/u2OYE5dOtViA==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-SAAwOxgoCKMGs9uUAUFHygfLAyaniaoun6I8mFY9pRAJL9+Kec34aU+oIjDhTycub1jozEfEwx1W1IuOYxVSFw==",
       "requires": {
-        "bytes": "3.1.1",
+        "bytes": "3.1.2",
         "content-type": "~1.0.4",
         "debug": "2.6.9",
         "depd": "~1.1.2",
         "http-errors": "1.8.1",
         "iconv-lite": "0.4.24",
         "on-finished": "~2.3.0",
-        "qs": "6.9.6",
-        "raw-body": "2.4.2",
+        "qs": "6.9.7",
+        "raw-body": "2.4.3",
         "type-is": "~1.6.18"
       },
       "dependencies": {
+        "http-errors": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+          "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.4",
+            "setprototypeof": "1.2.0",
+            "statuses": ">= 1.5.0 < 2",
+            "toidentifier": "1.0.1"
+          }
+        },
         "qs": {
-          "version": "6.9.6",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
-          "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ=="
+          "version": "6.9.7",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.7.tgz",
+          "integrity": "sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw=="
+        },
+        "raw-body": {
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.3.tgz",
+          "integrity": "sha512-UlTNLIcu0uzb4D2f4WltY6cVjLi+/jEN4lgEUj3E04tpMDpUlkBo/eSn6zou9hum2VMNpCCUone0O0WeJim07g==",
+          "requires": {
+            "bytes": "3.1.2",
+            "http-errors": "1.8.1",
+            "iconv-lite": "0.4.24",
+            "unpipe": "1.0.0"
+          }
+        },
+        "statuses": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+          "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
         }
       }
     },
@@ -2388,9 +2396,9 @@
       }
     },
     "bytes": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.1.tgz",
-      "integrity": "sha512-dWe4nWO/ruEOY7HkUJ5gFt1DCFV9zPRoJr8pV0/ASQermOZjtq8jMjOprC0Kd10GLN+l7xaUPvxzJFWtxGu8Fg=="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
     },
     "cacache": {
       "version": "15.3.0",
@@ -3162,9 +3170,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.21.0.tgz",
-      "integrity": "sha512-YUdI3fFu4TF/2WykQ2xzSiTQdldLB4KVuL9WeAy5XONZYt5Cun/fpQvctoKbCgvPhmzADeesTk/j2Rdx77AcKQ=="
+      "version": "3.21.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.21.1.tgz",
+      "integrity": "sha512-FRq5b/VMrWlrmCzwRrpDYNxyHP9BcAZC+xHJaqTgIE5091ZV1NTmyh0sGOg5XqpnHvR0svdy0sv1gWA1zmhxig=="
     },
     "core-util-is": {
       "version": "1.0.3",
@@ -4583,16 +4591,16 @@
       }
     },
     "express": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.17.2.tgz",
-      "integrity": "sha512-oxlxJxcQlYwqPWKVJJtvQiwHgosH/LrLSPA+H4UxpyvSS6jC5aH+5MoHFM+KABgTOt0APue4w66Ha8jCUo9QGg==",
+      "version": "4.17.3",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.3.tgz",
+      "integrity": "sha512-yuSQpz5I+Ch7gFrPCk4/c+dIBKlQUxtgwqzph132bsT6qhuzss6I8cLJQz7B3rFblzd6wtcI0ZbGltH/C4LjUg==",
       "requires": {
-        "accepts": "~1.3.7",
+        "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.19.1",
+        "body-parser": "1.19.2",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.4.1",
+        "cookie": "0.4.2",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "~1.1.2",
@@ -4607,7 +4615,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "0.1.7",
         "proxy-addr": "~2.0.7",
-        "qs": "6.9.6",
+        "qs": "6.9.7",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "0.17.2",
@@ -4619,15 +4627,15 @@
         "vary": "~1.1.2"
       },
       "dependencies": {
-        "cookie": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
-        },
         "qs": {
-          "version": "6.9.6",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
-          "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ=="
+          "version": "6.9.7",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.7.tgz",
+          "integrity": "sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw=="
+        },
+        "statuses": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+          "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
         }
       }
     },
@@ -4749,6 +4757,13 @@
         "parseurl": "~1.3.3",
         "statuses": "~1.5.0",
         "unpipe": "~1.0.0"
+      },
+      "dependencies": {
+        "statuses": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+          "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+        }
       }
     },
     "find-cache-dir": {
@@ -5589,15 +5604,22 @@
       "dev": true
     },
     "http-errors": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
-      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
       "requires": {
-        "depd": "~1.1.2",
+        "depd": "2.0.0",
         "inherits": "2.0.4",
         "setprototypeof": "1.2.0",
-        "statuses": ">= 1.5.0 < 2",
+        "statuses": "2.0.1",
         "toidentifier": "1.0.1"
+      },
+      "dependencies": {
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+        }
       }
     },
     "http-proxy-agent": {
@@ -6499,9 +6521,9 @@
       }
     },
     "json-pointer": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/json-pointer/-/json-pointer-0.6.1.tgz",
-      "integrity": "sha512-3OvjqKdCBvH41DLpV4iSt6v2XhZXV1bPB4OROuknvUXI7ZQNofieCPkmE26stEJ9zdQuvIxDHCuYhfgxFAAs+Q==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/json-pointer/-/json-pointer-0.6.2.tgz",
+      "integrity": "sha512-vLWcKbOaXlO+jvRy4qNd+TI1QUPZzfJj1tpJ3vAXDych5XJf93ftpUKe5pKCrzyIIwgBJcOcCVRUfqQP25afBw==",
       "requires": {
         "foreach": "^2.0.4"
       }
@@ -7547,8 +7569,7 @@
     "negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
-      "dev": true
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
     },
     "neo-async": {
       "version": "2.6.2",
@@ -8517,9 +8538,9 @@
           }
         },
         "yargs-parser": {
-          "version": "21.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
-          "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA=="
+          "version": "21.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+          "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg=="
         }
       }
     },
@@ -8692,9 +8713,9 @@
       }
     },
     "openapi-backend": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/openapi-backend/-/openapi-backend-5.2.0.tgz",
-      "integrity": "sha512-ykzFWC6pOPdw55/Qx7oxncymXh4Vuv+M5QCgaoIo38lAQ+hhzZXKl9AtSQfa6di9g5rKFs2yrGeAzUV7uLv6RQ==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/openapi-backend/-/openapi-backend-5.2.1.tgz",
+      "integrity": "sha512-JTRk+ytxvSZ+XZRLpfLyNzQnVWEwMZv7Bl9GVHwwaTadcVjuhK/WLg5xpuAvZwtV1LGLDujCc6w9QjEp0BWVHw==",
       "requires": {
         "@apidevtools/json-schema-ref-parser": "^9.0.7",
         "ajv": "^8.6.2",
@@ -8708,12 +8729,12 @@
       }
     },
     "openapi-sampler": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.1.1.tgz",
-      "integrity": "sha512-WAFsl5SPYuhQwaMTDFOcKhnEY1G1rmamrMiPmJdqwfl1lr81g63/befcsN9BNi0w5/R0L+hfcUj13PANEBeLgg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.2.1.tgz",
+      "integrity": "sha512-mHrYmyvcLD0qrfqPkPRBAL2z16hGT2rW0d0B7nklfoTcc3pmkJLkSZlKSeFgerUM41E5c7jlxf0Y19xrM7mWQQ==",
       "requires": {
         "@types/json-schema": "^7.0.7",
-        "json-pointer": "^0.6.1"
+        "json-pointer": "0.6.2"
       }
     },
     "openapi-schema-validator": {
@@ -9536,12 +9557,12 @@
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
     "raw-body": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.2.tgz",
-      "integrity": "sha512-RPMAFUJP19WIet/99ngh6Iv8fzAbqum4Li7AD6DtGaW2RpMB/11xDoalPiJMTbu6I3hkbMVkATvZrqb9EEqeeQ==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
+      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
       "requires": {
-        "bytes": "3.1.1",
-        "http-errors": "1.8.1",
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
       }
@@ -10028,6 +10049,25 @@
         "on-finished": "~2.3.0",
         "range-parser": "~1.2.1",
         "statuses": "~1.5.0"
+      },
+      "dependencies": {
+        "http-errors": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+          "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.4",
+            "setprototypeof": "1.2.0",
+            "statuses": ">= 1.5.0 < 2",
+            "toidentifier": "1.0.1"
+          }
+        },
+        "statuses": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+          "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+        }
       }
     },
     "serialize-error": {
@@ -11092,9 +11132,9 @@
       }
     },
     "statuses": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
     },
     "stream-combiner": {
       "version": "0.2.2",
@@ -12263,9 +12303,9 @@
       }
     },
     "urijs": {
-      "version": "1.19.7",
-      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.7.tgz",
-      "integrity": "sha512-Id+IKjdU0Hx+7Zx717jwLPsPeUqz7rAtuVBRLLs+qn+J2nf9NGITWVCxcijgYxBqe83C7sqsQPs6H1pyz3x9gA=="
+      "version": "1.19.8",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.8.tgz",
+      "integrity": "sha512-iIXHrjomQ0ZCuDRy44wRbyTZVnfVNLVo3Ksz1yxNyE5wV1IDZW2S5Jszy45DTlw/UdsnRT7DyDhIz7Gy+vJumw=="
     },
     "url-parse-lax": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1106,8 +1106,8 @@
       }
     },
     "@mojaloop/central-services-shared": {
-      "version": "git+ssh://git@github.com/mdebarros/central-services-shared.git#151a408e8001b3a301f37888fbc28f1fdfea9e74",
-      "from": "git+ssh://git@github.com/mdebarros/central-services-shared.git#feat/#2704-core-services-support-for-non-breaking-backward-api-compatibility",
+      "version": "git+https://github.com/mdebarros/central-services-shared.git#4acb926ca554d1533eb296d055d33b2ed94414f2",
+      "from": "git+https://github.com/mdebarros/central-services-shared.git#feat/#2704-core-services-support-for-non-breaking-backward-api-compatibility",
       "requires": {
         "@hapi/catbox": "11.1.1",
         "@hapi/catbox-memory": "5.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -477,9 +477,9 @@
       "integrity": "sha512-dDnQizD94EdBwEj/fh3zPRa/HWCS9O5au2PuHhZBbuM3xWHxuaKzPBOEWze7Nn0xW68MIpZ7Xdyn1CoCpjKCuQ=="
     },
     "@gar/promisify": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.2.tgz",
-      "integrity": "sha512-82cpyJyKRoQoRi+14ibCeGPu0CwypgtBAdBhq1WfvagpCZNKqwXbKwXllYSMG91DhmG4jt9gN8eP6lGOtozuaw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
+      "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
       "dev": true
     },
     "@grpc/proto-loader": {
@@ -1353,9 +1353,9 @@
       }
     },
     "@npmcli/fs": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.0.tgz",
-      "integrity": "sha512-VhP1qZLXcrXRIaPoqb4YA55JQxLNF3jNR4T55IdOJa3+IFJKNYHtPvtXx8slmeMavj37vCzCfrqQM1vWLsYKLA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
+      "integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
       "dev": true,
       "requires": {
         "@gar/promisify": "^1.0.1",
@@ -1374,21 +1374,28 @@
       }
     },
     "@npmcli/git": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-2.1.0.tgz",
-      "integrity": "sha512-/hBFX/QG1b+N7PZBFs0bi+evgRZcK9nWBxQKZkGoXUT5hJSwl5c4d7y8/hm+NQZRPhQ67RzFaj5UM9YeyKoryw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-3.0.0.tgz",
+      "integrity": "sha512-xfSBJ+KBMZWWqRHFbEgIaXG/LtELHrQZMJ72Gkb3yWdHysu/7+VGOs8ME0c3td7QNQX57Ggo3kYL6ylcd70/kA==",
       "dev": true,
       "requires": {
         "@npmcli/promise-spawn": "^1.3.2",
-        "lru-cache": "^6.0.0",
+        "lru-cache": "^7.3.1",
         "mkdirp": "^1.0.4",
-        "npm-pick-manifest": "^6.1.1",
+        "npm-pick-manifest": "^7.0.0",
+        "proc-log": "^2.0.0",
         "promise-inflight": "^1.0.1",
         "promise-retry": "^2.0.1",
         "semver": "^7.3.5",
         "which": "^2.0.2"
       },
       "dependencies": {
+        "lru-cache": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.4.0.tgz",
+          "integrity": "sha512-YOfuyWa/Ee+PXbDm40j9WXyJrzQUynVbgn4Km643UYcWNcrSfRkKL0WaiUcxcIbkXcVTgNpDqSnPXntWXT75cw==",
+          "dev": true
+        },
         "semver": {
           "version": "7.3.5",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -1396,6 +1403,17 @@
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
+          },
+          "dependencies": {
+            "lru-cache": {
+              "version": "6.0.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+              "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+              "dev": true,
+              "requires": {
+                "yallist": "^4.0.0"
+              }
+            }
           }
         },
         "which": {
@@ -1445,15 +1463,15 @@
       }
     },
     "@npmcli/run-script": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-2.0.0.tgz",
-      "integrity": "sha512-fSan/Pu11xS/TdaTpTB0MRn9guwGU8dye+x56mEVgBEd/QsybBbYcAL0phPXi8SGWFEChkQd6M9qL4y6VOpFig==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-3.0.0.tgz",
+      "integrity": "sha512-jIdmUepw+kVP2WEE/+XrBIvrSF5miDutdGBrQ8May6uHVAvpAb0m3NRHcJ0lKWbQ1BxsRFsmTrjkdY99qTTVIw==",
       "dev": true,
       "requires": {
-        "@npmcli/node-gyp": "^1.0.2",
+        "@npmcli/node-gyp": "^1.0.3",
         "@npmcli/promise-spawn": "^1.3.2",
-        "node-gyp": "^8.2.0",
-        "read-package-json-fast": "^2.0.1"
+        "node-gyp": "^8.4.1",
+        "read-package-json-fast": "^2.0.3"
       }
     },
     "@protobufjs/aspromise": {
@@ -1730,9 +1748,9 @@
       }
     },
     "agentkeepalive": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.0.tgz",
-      "integrity": "sha512-0PhAp58jZNw13UJv7NVdTGb0ZcghHUb3DrZ046JiiJY/BOaTTpbwdHq2VObPCBV8M2GPh7sgrJ3AQ8Ey468LJw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.1.tgz",
+      "integrity": "sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==",
       "dev": true,
       "requires": {
         "debug": "^4.1.0",
@@ -7620,20 +7638,20 @@
           }
         },
         "gauge": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.0.tgz",
-          "integrity": "sha512-F8sU45yQpjQjxKkm1UOAhf0U/O0aFt//Fl7hsrNVto+patMHjs7dPI9mFOGUKbhrgKm0S3EjW3scMFuQmWSROw==",
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.2.tgz",
+          "integrity": "sha512-aSPRm2CvA9R8QyU5eXMFPd+cYkyxLsXHd2l5/FOH2V/eml//M04G6KZOmTap07O1PvEwNcl2NndyLfK8g3QrKA==",
           "dev": true,
           "requires": {
             "ansi-regex": "^5.0.1",
             "aproba": "^1.0.3 || ^2.0.0",
-            "color-support": "^1.1.2",
-            "console-control-strings": "^1.0.0",
+            "color-support": "^1.1.3",
+            "console-control-strings": "^1.1.0",
             "has-unicode": "^2.0.1",
-            "signal-exit": "^3.0.0",
+            "signal-exit": "^3.0.7",
             "string-width": "^4.2.3",
             "strip-ansi": "^6.0.1",
-            "wide-align": "^1.1.2"
+            "wide-align": "^1.1.5"
           }
         },
         "npmlog": {
@@ -7656,6 +7674,12 @@
           "requires": {
             "lru-cache": "^6.0.0"
           }
+        },
+        "signal-exit": {
+          "version": "3.0.7",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+          "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+          "dev": true
         },
         "strip-ansi": {
           "version": "6.0.1",
@@ -7851,15 +7875,15 @@
       }
     },
     "npm-check-updates": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-12.3.0.tgz",
-      "integrity": "sha512-NcVpbVYZymmr7lVCwqz1wpkAgWNQ/XyyPy/yyR2IjCHU4Dr1lpIJgIgtC0PCDobcYuYXpYSIgIWZA7RFvq8+Rw==",
+      "version": "12.5.0",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-12.5.0.tgz",
+      "integrity": "sha512-nrryXO9IZdJsAIXo8LdtllrsGiTDE4IMAod7fl1jd5C38tOdZZG/crNNii4IkctxltQRmK/ziZwsMDTlhszZXg==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.2",
         "cint": "^8.2.1",
         "cli-table": "^0.3.11",
-        "commander": "^8.3.0",
+        "commander": "^9.0.0",
         "fast-memoize": "^2.5.2",
         "find-up": "5.0.0",
         "fp-and-or": "^0.1.3",
@@ -7870,9 +7894,9 @@
         "jsonlines": "^0.1.1",
         "libnpmconfig": "^1.2.1",
         "lodash": "^4.17.21",
-        "minimatch": "^3.0.4",
+        "minimatch": "^5.0.0",
         "p-map": "^4.0.0",
-        "pacote": "^12.0.2",
+        "pacote": "^13.0.2",
         "parse-github-url": "^1.0.2",
         "progress": "^2.0.3",
         "prompts": "^2.4.2",
@@ -7894,6 +7918,15 @@
           "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
+          }
+        },
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
           }
         },
         "chalk": {
@@ -7919,12 +7952,6 @@
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "commander": {
-          "version": "8.3.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-          "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
           "dev": true
         },
         "find-up": {
@@ -7959,6 +7986,15 @@
           "dev": true,
           "requires": {
             "p-locate": "^5.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+          "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
           }
         },
         "p-limit": {
@@ -8026,13 +8062,13 @@
       "dev": true
     },
     "npm-package-arg": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-8.1.5.tgz",
-      "integrity": "sha512-LhgZrg0n0VgvzVdSm1oiZworPbTxYHUJCgtsJW8mGvlDpxTM1vSJc3m5QZeUkhAHIzbz3VCHd/R4osi1L1Tg/Q==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-9.0.0.tgz",
+      "integrity": "sha512-yhzXxeor+Zfhe5MGwPdDumz6HtNlj2pMekWB95IX3CC6uDNgde0oPKHDCLDPoJqQfd0HqAWt+y4Hs5m7CK1+9Q==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^4.0.1",
-        "semver": "^7.3.4",
+        "hosted-git-info": "^4.1.0",
+        "semver": "^7.3.5",
         "validate-npm-package-name": "^3.0.0"
       },
       "dependencies": {
@@ -8069,15 +8105,15 @@
       }
     },
     "npm-pick-manifest": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-6.1.1.tgz",
-      "integrity": "sha512-dBsdBtORT84S8V8UTad1WlUyKIY9iMsAmqxHbLdeEeBNMLQDlDWWra3wYUx9EBEIiG/YwAy0XyNHDd2goAsfuA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-7.0.0.tgz",
+      "integrity": "sha512-njM1AcdioFaKd0JSGtLO09YA1WRwctjGQJbnHGmKS+u+uwP8oFvtZtOQWPYdxrnY5eJud3wn8OpH4sEIx6+GEQ==",
       "dev": true,
       "requires": {
         "npm-install-checks": "^4.0.0",
         "npm-normalize-package-bin": "^1.0.1",
-        "npm-package-arg": "^8.1.2",
-        "semver": "^7.3.4"
+        "npm-package-arg": "^9.0.0",
+        "semver": "^7.3.5"
       },
       "dependencies": {
         "semver": {
@@ -8092,17 +8128,18 @@
       }
     },
     "npm-registry-fetch": {
-      "version": "12.0.2",
-      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-12.0.2.tgz",
-      "integrity": "sha512-Df5QT3RaJnXYuOwtXBXS9BWs+tHH2olvkCLh6jcR/b/u3DvPMlp3J0TvvYwplPKxHMOwfg287PYih9QqaVFoKA==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-13.0.0.tgz",
+      "integrity": "sha512-MmiMuV9DU5gRuAU0jia952Qq+E4h7ZoUaeltCXivhClcqfOVKqNLZEQsRUOb6a8WQY+um8x97JcUuaWFoPoBBw==",
       "dev": true,
       "requires": {
-        "make-fetch-happen": "^10.0.1",
+        "make-fetch-happen": "^10.0.2",
         "minipass": "^3.1.6",
         "minipass-fetch": "^1.4.1",
         "minipass-json-stream": "^1.0.1",
         "minizlib": "^2.1.2",
-        "npm-package-arg": "^8.1.5"
+        "npm-package-arg": "^9.0.0",
+        "proc-log": "^2.0.0"
       },
       "dependencies": {
         "@tootallnate/once": {
@@ -8132,15 +8169,15 @@
           }
         },
         "lru-cache": {
-          "version": "7.3.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.3.1.tgz",
-          "integrity": "sha512-nX1x4qUrKqwbIAhv4s9et4FIUVzNOpeY07bsjGUy8gwJrXH/wScImSQqXErmo/b2jZY2r0mohbLA9zVj7u1cNw==",
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.4.0.tgz",
+          "integrity": "sha512-YOfuyWa/Ee+PXbDm40j9WXyJrzQUynVbgn4Km643UYcWNcrSfRkKL0WaiUcxcIbkXcVTgNpDqSnPXntWXT75cw==",
           "dev": true
         },
         "make-fetch-happen": {
-          "version": "10.0.1",
-          "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.0.1.tgz",
-          "integrity": "sha512-xJVRzemKMb9r2gZ5DJfkvbeSGbBKOtwI4G8hJ1Ak/2jIFJFveyQxN3d2OhXlAk7rLzAL/O+Ge8u+nb6/Zrrd9w==",
+          "version": "10.0.3",
+          "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.0.3.tgz",
+          "integrity": "sha512-CzarPHynPpHjhF5in/YapnO44rSZeYX5VCMfdXa99+gLwpbfFLh20CWa6dP/taV9Net9PWJwXNKtp/4ZTCQnag==",
           "dev": true,
           "requires": {
             "agentkeepalive": "^4.2.0",
@@ -8149,7 +8186,7 @@
             "http-proxy-agent": "^5.0.0",
             "https-proxy-agent": "^5.0.0",
             "is-lambda": "^1.0.1",
-            "lru-cache": "^7.3.0",
+            "lru-cache": "^7.3.1",
             "minipass": "^3.1.6",
             "minipass-collect": "^1.0.2",
             "minipass-fetch": "^1.4.1",
@@ -8844,30 +8881,85 @@
       }
     },
     "pacote": {
-      "version": "12.0.3",
-      "resolved": "https://registry.npmjs.org/pacote/-/pacote-12.0.3.tgz",
-      "integrity": "sha512-CdYEl03JDrRO3x18uHjBYA9TyoW8gy+ThVcypcDkxPtKlw76e4ejhYB6i9lJ+/cebbjpqPW/CijjqxwDTts8Ow==",
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/pacote/-/pacote-13.0.3.tgz",
+      "integrity": "sha512-8thQ06YoO01O1k5rvSpHS/XPJZucw2DPiiT1jI+ys8QaTN6ifAyxfyoABHBa8nIt/4wPdzly4GEPqshctHFoYA==",
       "dev": true,
       "requires": {
-        "@npmcli/git": "^2.1.0",
-        "@npmcli/installed-package-contents": "^1.0.6",
+        "@npmcli/git": "^3.0.0",
+        "@npmcli/installed-package-contents": "^1.0.7",
         "@npmcli/promise-spawn": "^1.2.0",
-        "@npmcli/run-script": "^2.0.0",
-        "cacache": "^15.0.5",
+        "@npmcli/run-script": "^3.0.0",
+        "cacache": "^15.3.0",
         "chownr": "^2.0.0",
         "fs-minipass": "^2.1.0",
         "infer-owner": "^1.0.4",
-        "minipass": "^3.1.3",
-        "mkdirp": "^1.0.3",
-        "npm-package-arg": "^8.0.1",
+        "minipass": "^3.1.6",
+        "mkdirp": "^1.0.4",
+        "npm-package-arg": "^9.0.0",
         "npm-packlist": "^3.0.0",
-        "npm-pick-manifest": "^6.0.0",
-        "npm-registry-fetch": "^12.0.0",
+        "npm-pick-manifest": "^7.0.0",
+        "npm-registry-fetch": "^13.0.0",
+        "proc-log": "^2.0.0",
         "promise-retry": "^2.0.1",
-        "read-package-json-fast": "^2.0.1",
+        "read-package-json": "^4.1.1",
+        "read-package-json-fast": "^2.0.3",
         "rimraf": "^3.0.2",
         "ssri": "^8.0.1",
-        "tar": "^6.1.0"
+        "tar": "^6.1.11"
+      },
+      "dependencies": {
+        "hosted-git-info": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+          "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "minipass": {
+          "version": "3.1.6",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
+          "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "normalize-package-data": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+          "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^4.0.1",
+            "is-core-module": "^2.5.0",
+            "semver": "^7.3.4",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "read-package-json": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-4.1.1.tgz",
+          "integrity": "sha512-P82sbZJ3ldDrWCOSKxJT0r/CXMWR0OR3KRh55SgKo3p91GSIEEC32v3lSHAvO/UcH3/IoL7uqhOFBduAnwdldw==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.1",
+            "json-parse-even-better-errors": "^2.3.0",
+            "normalize-package-data": "^3.0.0",
+            "npm-normalize-package-bin": "^1.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "parent-module": {
@@ -9237,6 +9329,12 @@
         "parse-ms": "^1.0.0",
         "plur": "^1.0.0"
       }
+    },
+    "proc-log": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-2.0.0.tgz",
+      "integrity": "sha512-I/35MfCX2H8jBUhKN8JB8nmqvQo/nKdrBodBY7L3RhDSPPyvOHwLYNmPuhwuJq7a7C3vgFKWGQM+ecPStcvOHA==",
+      "dev": true
     },
     "process": {
       "version": "0.10.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1106,8 +1106,9 @@
       }
     },
     "@mojaloop/central-services-shared": {
-      "version": "git+https://github.com/mdebarros/central-services-shared.git#4acb926ca554d1533eb296d055d33b2ed94414f2",
-      "from": "git+https://github.com/mdebarros/central-services-shared.git#feat/#2704-core-services-support-for-non-breaking-backward-api-compatibility",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@mojaloop/central-services-shared/-/central-services-shared-16.0.0.tgz",
+      "integrity": "sha512-B/7RJIWlCtNpf08wheGT2Siq/2XHIBUcINTRZWyZ5ObQH0IQCsHu46eMvlN4gNIiuCkfFBxIVbbDlD41ooM4cw==",
       "requires": {
         "@hapi/catbox": "11.1.1",
         "@hapi/catbox-memory": "5.0.1",
@@ -12303,9 +12304,9 @@
       }
     },
     "urijs": {
-      "version": "1.19.8",
-      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.8.tgz",
-      "integrity": "sha512-iIXHrjomQ0ZCuDRy44wRbyTZVnfVNLVo3Ksz1yxNyE5wV1IDZW2S5Jszy45DTlw/UdsnRT7DyDhIz7Gy+vJumw=="
+      "version": "1.19.9",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.9.tgz",
+      "integrity": "sha512-v0V+v5F3NQFt6TX0GpA2NKyrpythDJI+PHRo66sUIDP/U6cXbm6NqLVcXylQGwiwW5VYNj+OAei3EU0ALj9AWg=="
     },
     "url-parse-lax": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "license-checker": "25.0.1",
     "nodemon": "2.0.15",
     "npm-audit-resolver": "2.3.1",
-    "npm-check-updates": "12.3.0",
+    "npm-check-updates": "12.5.0",
     "npm-run-all": "4.1.5",
     "nyc": "15.1.0",
     "pre-commit": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@mojaloop/central-services-health": "13.0.0",
     "@mojaloop/central-services-logger": "10.6.2",
     "@mojaloop/central-services-metrics": "11.0.0",
-    "@mojaloop/central-services-shared": "https://github.com/mdebarros/central-services-shared.git#feat/%232704-core-services-support-for-non-breaking-backward-api-compatibility",
+    "@mojaloop/central-services-shared": "16.0.0",
     "@mojaloop/central-services-stream": "10.7.0",
     "@mojaloop/event-sdk": "10.7.1",
     "@mojaloop/forensic-logging-client": "8.3.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@mojaloop/central-services-health": "13.0.0",
     "@mojaloop/central-services-logger": "10.6.2",
     "@mojaloop/central-services-metrics": "11.0.0",
-    "@mojaloop/central-services-shared": "15.3.0",
+    "@mojaloop/central-services-shared": "git@github.com:mdebarros/central-services-shared.git#feat/%232704-core-services-support-for-non-breaking-backward-api-compatibility",
     "@mojaloop/central-services-stream": "10.7.0",
     "@mojaloop/event-sdk": "10.7.1",
     "@mojaloop/forensic-logging-client": "8.3.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@mojaloop/central-services-health": "13.0.0",
     "@mojaloop/central-services-logger": "10.6.2",
     "@mojaloop/central-services-metrics": "11.0.0",
-    "@mojaloop/central-services-shared": "git@github.com:mdebarros/central-services-shared.git#feat/%232704-core-services-support-for-non-breaking-backward-api-compatibility",
+    "@mojaloop/central-services-shared": "https://github.com/mdebarros/central-services-shared.git#feat/%232704-core-services-support-for-non-breaking-backward-api-compatibility",
     "@mojaloop/central-services-stream": "10.7.0",
     "@mojaloop/event-sdk": "10.7.1",
     "@mojaloop/forensic-logging-client": "8.3.0",

--- a/src/handlers/notification/index.js
+++ b/src/handlers/notification/index.js
@@ -449,7 +449,7 @@ const processMessage = async (msg, span) => {
   // special event emitted by central-ledger when the Payee sent a status of `RESERVED` in PUT /transfers/{ID}
   // and the ledger failed to commit the transfer
   if (actionLower === ENUM.Events.Event.Action.RESERVED_ABORTED) {
-    if (Config.PROTOCOL_VERSIONS.CONTENT !== '1.1') {
+    if (Config.PROTOCOL_VERSIONS.CONTENT.DEFAULT !== '1.1') {
       Logger.isDebugEnabled && Logger.debug(`Notification::processMessage - Action: ${actionLower} - Skipping reserved_aborted notification callback (${from}).`)
       return
     }

--- a/src/handlers/notification/index.js
+++ b/src/handlers/notification/index.js
@@ -260,7 +260,7 @@ const processMessage = async (msg, span) => {
 
   // Injected Configuration for outbound Content-Type & Accept headers.
   const protocolVersions = {
-    content: Config.PROTOCOL_VERSIONS.CONTENT.toString(),
+    content: Config.PROTOCOL_VERSIONS.CONTENT.DEFAULT.toString(),
     accept: Config.PROTOCOL_VERSIONS.ACCEPT.DEFAULT.toString()
   }
 

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -11,11 +11,18 @@ const getFileContent = (path) => {
 }
 
 const DEFAULT_PROTOCOL_VERSION = {
-  CONTENT: '1.1',
+  CONTENT: {
+    DEFAULT: '1.1',
+    VALIDATELIST: [
+      '1.0',
+      '1.1'
+    ]
+  },
   ACCEPT: {
     DEFAULT: '1',
     VALIDATELIST: [
       '1',
+      '1.0',
       '1.1'
     ]
   }
@@ -26,11 +33,24 @@ const getProtocolVersions = (defaultProtocolVersions, overrideProtocolVersions) 
     ...defaultProtocolVersions,
     ...overrideProtocolVersions
   }
+  if (overrideProtocolVersions && overrideProtocolVersions.CONTENT) {
+    T_PROTOCOL_VERSION.CONTENT = {
+      ...defaultProtocolVersions.CONTENT,
+      ...overrideProtocolVersions.CONTENT
+    }
+  }
+
   if (overrideProtocolVersions && overrideProtocolVersions.ACCEPT) {
     T_PROTOCOL_VERSION.ACCEPT = {
       ...defaultProtocolVersions.ACCEPT,
       ...overrideProtocolVersions.ACCEPT
     }
+  }
+  if (T_PROTOCOL_VERSION.CONTENT &&
+    T_PROTOCOL_VERSION.CONTENT.VALIDATELIST &&
+    (typeof T_PROTOCOL_VERSION.CONTENT.VALIDATELIST === 'string' ||
+      T_PROTOCOL_VERSION.CONTENT.VALIDATELIST instanceof String)) {
+    T_PROTOCOL_VERSION.CONTENT.VALIDATELIST = JSON.parse(T_PROTOCOL_VERSION.CONTENT.VALIDATELIST)
   }
   if (T_PROTOCOL_VERSION.ACCEPT &&
     T_PROTOCOL_VERSION.ACCEPT.VALIDATELIST &&

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -33,19 +33,20 @@ const getProtocolVersions = (defaultProtocolVersions, overrideProtocolVersions) 
     ...defaultProtocolVersions,
     ...overrideProtocolVersions
   }
+
   if (overrideProtocolVersions && overrideProtocolVersions.CONTENT) {
     T_PROTOCOL_VERSION.CONTENT = {
       ...defaultProtocolVersions.CONTENT,
       ...overrideProtocolVersions.CONTENT
     }
   }
-
   if (overrideProtocolVersions && overrideProtocolVersions.ACCEPT) {
     T_PROTOCOL_VERSION.ACCEPT = {
       ...defaultProtocolVersions.ACCEPT,
       ...overrideProtocolVersions.ACCEPT
     }
   }
+
   if (T_PROTOCOL_VERSION.CONTENT &&
     T_PROTOCOL_VERSION.CONTENT.VALIDATELIST &&
     (typeof T_PROTOCOL_VERSION.CONTENT.VALIDATELIST === 'string' ||

--- a/src/shared/plugins.js
+++ b/src/shared/plugins.js
@@ -69,7 +69,10 @@ const registerPlugins = async (server) => {
   // Helper to construct FSPIOPHeaderValidation option configuration
   const getOptionsForFSPIOPHeaderValidation = () => {
     // configure supported FSPIOP Content-Type versions
-    const supportedProtocolContentVersions = [Config.PROTOCOL_VERSIONS.CONTENT.toString()]
+    const supportedProtocolContentVersions = []
+    for (const version of Config.PROTOCOL_VERSIONS.CONTENT.VALIDATELIST) {
+      supportedProtocolContentVersions.push(version.toString())
+    }
 
     // configure supported FSPIOP Accept version
     const supportedProtocolAcceptVersions = []

--- a/test/unit/handlers/notification/index.test.js
+++ b/test/unit/handlers/notification/index.test.js
@@ -72,6 +72,8 @@ Test('Notification Service tests', async notificationTest => {
     sandbox.stub(Callback, 'sendRequest').returns(Promise.resolve(true))
     sandbox.stub(JwsSigner.prototype, 'constructor')
     sandbox.stub(JwsSigner.prototype, 'getSignature').returns(true)
+
+    Proxyquire.callThru()
     t.end()
   })
 
@@ -180,7 +182,13 @@ Test('Notification Service tests', async notificationTest => {
       const ConfigStub = Util.clone(Config)
       // override the PROTOCOL_VERSIONS config
       ConfigStub.PROTOCOL_VERSIONS = {
-        CONTENT: '2.1',
+        CONTENT: {
+          DEFAULT: '2.1',
+          VALIDATELIST: [
+            '2',
+            '2.1'
+          ]
+        },
         ACCEPT: {
           DEFAULT: '2',
           VALIDATELIST: [
@@ -229,7 +237,7 @@ Test('Notification Service tests', async notificationTest => {
       const result = await NotificationProxy.processMessage(msg)
       test.ok(Callback.sendRequest.calledWith(url, headers, msg.value.from, msg.value.to, method, JSON.stringify(message)))
       test.equal(result, expected)
-      test.equal(Callback.sendRequest.args[0][9].content, ConfigStub.PROTOCOL_VERSIONS.CONTENT)
+      test.equal(Callback.sendRequest.args[0][9].content, ConfigStub.PROTOCOL_VERSIONS.CONTENT.DEFAULT)
       test.equal(Callback.sendRequest.args[0][9].accept, ConfigStub.PROTOCOL_VERSIONS.ACCEPT.DEFAULT)
       test.end()
     })
@@ -1962,7 +1970,7 @@ Test('Notification Service tests', async notificationTest => {
     await processMessageTest.test('ignore a RESERVED_ABORTED message if the API version !== 1.1', async test => {
       // Arrange
       const ConfigStub = Util.clone(Config)
-      ConfigStub.PROTOCOL_VERSIONS.CONTENT = '1.2'
+      ConfigStub.PROTOCOL_VERSIONS.CONTENT.DEFAULT = '1.2'
       ConfigStub.JWS_SIGN = false
       const NotificationProxy = Proxyquire(`${src}/handlers/notification`, {
         '../../lib/config': ConfigStub
@@ -2012,8 +2020,9 @@ Test('Notification Service tests', async notificationTest => {
     await processMessageTest.test('process a RESERVED_ABORTED message if the API version === 1.1', async test => {
       // Arrange
       const ConfigStub = Util.clone(Config)
-      ConfigStub.PROTOCOL_VERSIONS.CONTENT = '1.1'
+      ConfigStub.PROTOCOL_VERSIONS.CONTENT.DEFAULT = '1.1'
       ConfigStub.JWS_SIGN = false
+
       const NotificationProxy = Proxyquire(`${src}/handlers/notification`, {
         '../../lib/config': ConfigStub
       })
@@ -2084,7 +2093,7 @@ Test('Notification Service tests', async notificationTest => {
     await processMessageTest.test('throws an error if Callback.sendRequest fails', async test => {
       // Arrange
       const ConfigStub = Util.clone(Config)
-      ConfigStub.PROTOCOL_VERSIONS.CONTENT = '1.1'
+      ConfigStub.PROTOCOL_VERSIONS.CONTENT.DEFAULT = '1.1'
       ConfigStub.JWS_SIGN = false
       const NotificationProxy = Proxyquire(`${src}/handlers/notification`, {
         '../../lib/config': ConfigStub

--- a/test/unit/lib/config.test.js
+++ b/test/unit/lib/config.test.js
@@ -65,6 +65,7 @@ Test('Config tests', configTest => {
         DefaultStub.ENDPOINT_SECURITY.JWS.JWS_SIGN = true
         // set env var
         const validateList = ['1']
+        process.env.MLAPI_PROTOCOL_VERSIONS__CONTENT__VALIDATELIST = JSON.stringify(validateList)
         process.env.MLAPI_PROTOCOL_VERSIONS__ACCEPT__VALIDATELIST = JSON.stringify(validateList)
         const Config = Proxyquire(`${src}/lib/config`, {
           '../../config/default.json': DefaultStub
@@ -73,8 +74,13 @@ Test('Config tests', configTest => {
         console.log('config', JSON.stringify(Config.PROTOCOL_VERSIONS))
         test.ok('pass')
         test.deepEqual(Config.PROTOCOL_VERSIONS.ACCEPT.VALIDATELIST, validateList)
+        test.deepEqual(Config.PROTOCOL_VERSIONS.CONTENT.VALIDATELIST, validateList)
       } catch (e) {
         test.fail('should throw')
+      } finally {
+        // remove env vars so they will not impact other tests
+        delete process.env.MLAPI_PROTOCOL_VERSIONS__CONTENT__VALIDATELIST
+        delete process.env.MLAPI_PROTOCOL_VERSIONS__ACCEPT__VALIDATELIST
       }
       test.end()
     })
@@ -83,17 +89,28 @@ Test('Config tests', configTest => {
       // Arrange
       const DefaultStub = Util.clone(Default)
       DefaultStub.PROTOCOL_VERSIONS = {
-        CONTENT: '1.1',
+        CONTENT: {
+          DEFAULT: '1.1',
+          VALIDATELIST: [
+            '1.1'
+          ]
+        },
         ACCEPT: {
+          DEFAULT: '1.0',
           VALIDATELIST: [
             '1'
           ]
         }
       }
       const expected = {
-        CONTENT: '1.1',
+        CONTENT: {
+          DEFAULT: '1.1',
+          VALIDATELIST: [
+            '1.1'
+          ]
+        },
         ACCEPT: {
-          DEFAULT: '1',
+          DEFAULT: '1.0',
           VALIDATELIST: [
             '1'
           ]


### PR DESCRIPTION
feat(mojaloop/#2704): core-services support for non-breaking backward api compatibility - https://github.com/mojaloop/project/issues/2704
- updated default.json config for PROTOCOL_VERSIONS, and updated related usage based on https://github.com/mojaloop/project/issues/2660 to accept a validationList for the content-type
- updated dependencies
- fixed audit issues
- fixed unit tests

BREAKING CHANGE:
- Config PROTOCOL_VERSIONS.CONTENT has now been modified to support backward compatibility for minor versions (i.e. v1.0 & 1.1) as follows:

> ```
>   "PROTOCOL_VERSIONS": {
>     "CONTENT": "1.1", <-- used when generating messages from the "SWITCH", and validate incoming FSPIOP API requests/callbacks CONTENT-TYPE headers
>     "ACCEPT": {
>       "DEFAULT": "1", <-- used when generating messages from the "SWITCH"
>       "VALIDATELIST": [ <-- used to validate incoming FSPIOP API requests/callbacks ACCEPT headers
>         "1",
>         "1.0",
>         "1.1"
>       ]
>     }
>   },
> ```
> 
> to be consistent with the ACCEPT structure as follows:
> 
> ```
>   "PROTOCOL_VERSIONS": {
>     "CONTENT": {
>       "DEFAULT": "1.1", <-- used when generating messages from the "SWITCH"
>       "VALIDATELIST": [ <-- used to validate incoming FSPIOP API requests/callbacks CONTENT-TYPE headers
>         "1.1",
>         "1.0"
>       ]
>     },
>     "ACCEPT": {
>       "DEFAULT": "1", <-- used when generating messages from the "SWITCH"
>       "VALIDATELIST": [ <-- used to validate incoming FSPIOP API requests/callbacks ACCEPT headers
>         "1",
>         "1.0",
>         "1.1"
>       ]
>     }
>   },
> ```