### PR TITLE
fix: notify-decouple

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,7 @@ services:
       - central-ledger
       - kafka
     healthcheck:
-      test: ["CMD", "sh", "-c" ,"set -e;apk --no-cache add curl;curl --fail http://localhost:4545/health"]
+      test: ["CMD", "sh", "-c" ,"set -e;apk --no-cache add curl;curl --fail http://localhost:4545"]
       timeout: 20s
       retries: 10
       interval: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -229,6 +229,7 @@ services:
 
 
   redis-node-0:
+    container_name: redis-node-0
     <<: *REDIS_NODE
     environment:
       <<: *REDIS_ENVS
@@ -243,12 +244,17 @@ services:
       - "6379:6379"
 
   redis-node-1:
+    container_name: redis-node-1
     <<: *REDIS_NODE
   redis-node-2:
+    container_name: redis-node-2
     <<: *REDIS_NODE
   redis-node-3:
+    container_name: redis-node-3
     <<: *REDIS_NODE
   redis-node-4:
+    container_name: redis-node-4
     <<: *REDIS_NODE
   redis-node-5:
+    container_name: redis-node-5
     <<: *REDIS_NODE

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - central-ledger
       - kafka
     healthcheck:
-      test: ["CMD", "sh", "-c" ,"apk --no-cache add curl", ";", "curl", "--fail", "http://localhost:3000/health"]
+      test: ["CMD", "sh", "-c" ,"set -e;apk --no-cache add curl;curl --fail http://localhost:3000/health"]
       timeout: 20s
       retries: 10
       interval: 30s
@@ -63,7 +63,7 @@ services:
       - central-ledger
       - kafka
     healthcheck:
-      test: ["CMD", "sh", "-c" ,"apk --no-cache add curl", ";", "curl", "--fail", "http://localhost:4545/health"]
+      test: ["CMD", "sh", "-c" ,"set -e;apk --no-cache add curl;curl --fail http://localhost:4545/health"]
       timeout: 20s
       retries: 10
       interval: 30s
@@ -92,7 +92,7 @@ services:
       - ml-mojaloop-net
     user: 'root'
     healthcheck:
-      test: ["CMD", "sh", "-c" ,"apk --no-cache add curl", ";", "curl", "--fail", "http://localhost:3001/health"]
+      test: ["CMD", "sh", "-c" ,"set -e;apk --no-cache add curl;curl --fail http://localhost:3001/health"]
       timeout: 20s
       retries: 10
       interval: 30s
@@ -207,7 +207,7 @@ services:
     networks:
       - ml-mojaloop-net
     healthcheck:
-      test: ["CMD", "sh", "-c" ,"apk --no-cache add curl", ";", "curl", "--fail", "http://localhost:8444/health"]
+      test: ["CMD", "sh", "-c" ,"set -e;apk --no-cache add curl;curl --fail http://localhost:8444/health"]
       timeout: 20s
       retries: 10
       interval: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,7 +72,7 @@ services:
     # image: mojaloop/central-ledger:latest
     image: mojaloop/central-ledger:v17.8.0-snapshot.34
     container_name: ml_central-ledger
-    command: sh -c "/opt/app/wait4/wait4.js central-ledger && npm run migrate && node src/api/index.js"
+    command: sh -c "node /opt/app/wait4/wait4.js central-ledger && npm run migrate && node src/api/index.js"
     links:
       - mysql
       - kafka
@@ -99,7 +99,7 @@ services:
 
   central-handler-position-batch:
     image: mojaloop/central-ledger:v17.8.0-snapshot.34
-    command: sh -c " /opt/app/wait4/wait4.js central-ledger && "CLEDG_HANDLERS__API__DISABLED=true" node src/handlers/index.js handler --positionbatch"
+    command: sh -c "node /opt/app/wait4/wait4.js central-ledger && "CLEDG_HANDLERS__API__DISABLED=true" node src/handlers/index.js handler --positionbatch"
     ports:
       - "3002:3001"
     links:

--- a/src/handlers/notification/index.js
+++ b/src/handlers/notification/index.js
@@ -355,6 +355,8 @@ const processMessage = async (msg, span) => {
     return true
   }
 
+  const sendToSource = Config.SEND_TRANSFER_CONFIRMATION_TO_PAYEE && source !== destination
+
   if ([Action.COMMIT, Action.RESERVE, Action.FX_COMMIT, Action.FX_RESERVE].includes(action) && isSuccess) {
     const callbackURLTo = await getEndpointFn(destination, REQUEST_TYPE.PUT)
     const endpointTemplate = getEndpointTemplate(REQUEST_TYPE.PUT)
@@ -384,7 +386,7 @@ const processMessage = async (msg, span) => {
 
     // send an extra notification back to the original sender (if enabled in config) and ignore this for on-us transfers
     // todo: do we need this case for FX_RESERVE ?
-    if ((action === Action.RESERVE) || (Config.SEND_TRANSFER_CONFIRMATION_TO_PAYEE && source !== destination && action !== Action.FX_RESERVE)) {
+    if ((action === Action.RESERVE) || (sendToSource && action !== Action.FX_RESERVE)) {
       let payloadForPayee = JSON.parse(payload)
       if (payloadForPayee.fulfilment && action === Action.RESERVE) {
         delete payloadForPayee.fulfilment
@@ -430,55 +432,60 @@ const processMessage = async (msg, span) => {
   }
 
   if ([Action.REJECT, Action.FX_REJECT].includes(action)) {
-    const [callbackURLFrom, callbackURLTo] = await Promise.all([
-      getEndpointFn(source, REQUEST_TYPE.PUT),
-      getEndpointFn(destination, REQUEST_TYPE.PUT)
-    ])
     const endpointTemplate = getEndpointTemplate(REQUEST_TYPE.PUT)
-    headers = createCallbackHeaders({ dfspId: destination, transferId: id, headers: content.headers, httpMethod: PUT, endpointTemplate })
-    // forward the reject to the destination
-    logger.debug(`Notification::processMessage - Callback.sendRequest({ ${callbackURLTo}, ${PUT}, ${JSON.stringify(headers)}, ${payload}, ${id}, ${source}, ${destination} ${hubNameRegex} })`)
-    await Callback.sendRequest({ url: callbackURLTo, headers, source, destination, method: PUT, payload, responseType, span, protocolVersions, hubNameRegex })
+    const [, response] = await Promise.all([
+      (async function notifyDestination () {
+        const callbackURLTo = await getEndpointFn(destination, REQUEST_TYPE.PUT)
+        headers = createCallbackHeaders({ dfspId: destination, transferId: id, headers: content.headers, httpMethod: PUT, endpointTemplate })
+        // forward the reject to the destination
+        logger.debug(`Notification::processMessage - Callback.sendRequest({ ${callbackURLTo}, ${PUT}, ${JSON.stringify(headers)}, ${payload}, ${id}, ${source}, ${destination} ${hubNameRegex} })`)
+        await Callback.sendRequest({ url: callbackURLTo, headers, source, destination, method: PUT, payload, responseType, span, protocolVersions, hubNameRegex })
+      })(),
+      // send an extra notification back to the original sender (if enabled in config) and ignore this for on-us transfers
+      (async function notifySource () {
+        if (sendToSource) {
+          const callbackURLFrom = await getEndpointFn(source, REQUEST_TYPE.PUT)
+          jwsSigner = getJWSSigner(Config.HUB_NAME)
+          logger.debug(`Notification::processMessage - Callback.sendRequest({ ${callbackURLFrom}, ${PUT}, ${JSON.stringify(headers)}, ${payload}, ${id}, ${Config.HUB_NAME}, ${source}, ${hubNameRegex} })`)
+          headers = createCallbackHeaders({ dfspId: source, transferId: id, headers: content.headers, httpMethod: PUT, endpointTemplate }, fromSwitch)
+          return await Callback.sendRequest({ url: callbackURLFrom, headers, source: Config.HUB_NAME, destination: source, method: PUT, payload, responseType, span, jwsSigner, protocolVersions, hubNameRegex })
+        } else {
+          logger.info(`Notification::processMessage - Action: ${action} - Skipping notification callback to original sender (${source}) because feature is disabled in config.`)
+          return true
+        }
+      })()
+    ])
 
-    // send an extra notification back to the original sender (if enabled in config) and ignore this for on-us transfers
-    if (Config.SEND_TRANSFER_CONFIRMATION_TO_PAYEE && source !== destination) {
-      jwsSigner = getJWSSigner(Config.HUB_NAME)
-      logger.debug(`Notification::processMessage - Callback.sendRequest({ ${callbackURLFrom}, ${PUT}, ${JSON.stringify(headers)}, ${payload}, ${id}, ${Config.HUB_NAME}, ${source}, ${hubNameRegex} })`)
-      headers = createCallbackHeaders({ dfspId: source, transferId: id, headers: content.headers, httpMethod: PUT, endpointTemplate }, fromSwitch)
-      const response = await Callback.sendRequest({ url: callbackURLFrom, headers, source: Config.HUB_NAME, destination: source, method: PUT, payload, responseType, span, jwsSigner, protocolVersions, hubNameRegex })
-      histTimerEnd({ success: true, action })
-      return response
-    } else {
-      logger.info(`Notification::processMessage - Action: ${action} - Skipping notification callback to original sender (${source}) because feature is disabled in config.`)
-    }
     histTimerEnd({ success: true, action })
-    return true
+    return response
   }
 
   if ([Action.ABORT, Action.FX_ABORT].includes(action)) {
-    const [callbackURLFrom, callbackURLTo] = await Promise.all([
-      getEndpointFn(source, REQUEST_TYPE.PUT_ERROR),
-      getEndpointFn(destination, REQUEST_TYPE.PUT_ERROR)
-    ])
     const endpointTemplate = getEndpointTemplate(REQUEST_TYPE.PUT_ERROR)
-    headers = createCallbackHeaders({ dfspId: destination, transferId: id, headers: content.headers, httpMethod: PUT, endpointTemplate })
-    // forward the abort to the destination
-    logger.debug(`Notification::processMessage - Callback.sendRequest({ ${callbackURLTo}, ${PUT}, ${JSON.stringify(headers)}, ${payload}, ${id}, ${source}, ${destination} ${hubNameRegex} })`)
-    await Callback.sendRequest({ url: callbackURLTo, headers, source, destination, method: PUT, payload, responseType, span, protocolVersions, hubNameRegex })
-
-    // send an extra notification back to the original sender (if enabled in config) and ignore this for on-us transfers
-    if (Config.SEND_TRANSFER_CONFIRMATION_TO_PAYEE && source !== destination) {
-      jwsSigner = getJWSSigner(Config.HUB_NAME)
-      logger.debug(`Notification::processMessage - Callback.sendRequest({ ${callbackURLFrom}, ${PUT}, ${JSON.stringify(headers)}, ${payload}, ${id}, ${Config.HUB_NAME}, ${source} ${hubNameRegex} })`)
-      headers = createCallbackHeaders({ dfspId: source, transferId: id, headers: content.headers, httpMethod: PUT, endpointTemplate }, fromSwitch)
-      const response = await Callback.sendRequest({ url: callbackURLFrom, headers, source: Config.HUB_NAME, destination: source, method: PUT, payload, responseType, span, jwsSigner, protocolVersions, hubNameRegex })
-      histTimerEnd({ success: true, action })
-      return response
-    } else {
-      logger.info(`Notification::processMessage - Action: ${action} - Skipping notification callback to original sender (${source}).`)
-    }
+    const [, response] = await Promise.all([
+      (async function notifyDestination () {
+        const callbackURLTo = await getEndpointFn(destination, REQUEST_TYPE.PUT_ERROR)
+        headers = createCallbackHeaders({ dfspId: destination, transferId: id, headers: content.headers, httpMethod: PUT, endpointTemplate })
+        // forward the abort to the destination
+        logger.debug(`Notification::processMessage - Callback.sendRequest({ ${callbackURLTo}, ${PUT}, ${JSON.stringify(headers)}, ${payload}, ${id}, ${source}, ${destination} ${hubNameRegex} })`)
+        await Callback.sendRequest({ url: callbackURLTo, headers, source, destination, method: PUT, payload, responseType, span, protocolVersions, hubNameRegex })
+      })(),
+      (async function notifySource () {
+        // send an extra notification back to the original sender (if enabled in config) and ignore this for on-us transfers
+        if (sendToSource) {
+          const callbackURLFrom = await getEndpointFn(source, REQUEST_TYPE.PUT_ERROR)
+          jwsSigner = getJWSSigner(Config.HUB_NAME)
+          logger.debug(`Notification::processMessage - Callback.sendRequest({ ${callbackURLFrom}, ${PUT}, ${JSON.stringify(headers)}, ${payload}, ${id}, ${Config.HUB_NAME}, ${source} ${hubNameRegex} })`)
+          headers = createCallbackHeaders({ dfspId: source, transferId: id, headers: content.headers, httpMethod: PUT, endpointTemplate }, fromSwitch)
+          return await Callback.sendRequest({ url: callbackURLFrom, headers, source: Config.HUB_NAME, destination: source, method: PUT, payload, responseType, span, jwsSigner, protocolVersions, hubNameRegex })
+        } else {
+          logger.info(`Notification::processMessage - Action: ${action} - Skipping notification callback to original sender (${source}).`)
+          return true
+        }
+      })()
+    ])
     histTimerEnd({ success: true, action })
-    return true
+    return response
   }
 
   if ([Action.ABORT_VALIDATION, Action.FX_ABORT_VALIDATION].includes(action)) {
@@ -491,7 +498,7 @@ const processMessage = async (msg, span) => {
     await Callback.sendRequest({ url: callbackURLTo, headers, source: Config.HUB_NAME, destination, method: PUT, payload, responseType, span, jwsSigner, protocolVersions, hubNameRegex })
 
     // send an extra notification back to the original sender (if enabled in config) and ignore this for on-us transfers
-    if (Config.SEND_TRANSFER_CONFIRMATION_TO_PAYEE && source !== destination && source !== Config.HUB_NAME) {
+    if (sendToSource && source !== Config.HUB_NAME) {
       const callbackURLFrom = await getEndpointFn(source, REQUEST_TYPE.PUT_ERROR)
       logger.debug(`Notification::processMessage - Callback.sendRequest({ ${callbackURLFrom}, ${PUT}, ${JSON.stringify(headers)}, ${payload}, ${id}, ${Config.HUB_NAME}, ${source}, ${hubNameRegex} })`)
       headers = createCallbackHeaders({ dfspId: source, transferId: id, headers: content.headers, httpMethod: PUT, endpointTemplate }, fromSwitch)

--- a/test/unit/handlers/notification/index.test.js
+++ b/test/unit/handlers/notification/index.test.js
@@ -1643,8 +1643,8 @@ Test('Notification Service tests', async notificationTest => {
 
       const result = await Notification.processMessage(msg)
 
-      test.ok(Participant.getEndpoint.getCall(0).calledWith(match({ fsp: msg.value.from, endpointType: ENUM.EndPoints.FspEndpointTypes.FSPIOP_CALLBACK_URL_FX_TRANSFER_PUT, id: msg.value.content.payload.commitRequestId, isFx: true, span: undefined })))
-      test.ok(Participant.getEndpoint.getCall(1).calledWith(match({ fsp: msg.value.to, endpointType: ENUM.EndPoints.FspEndpointTypes.FSPIOP_CALLBACK_URL_FX_TRANSFER_PUT, id: msg.value.content.payload.commitRequestId, isFx: true, span: undefined })))
+      test.ok(Participant.getEndpoint.getCall(1).calledWith(match({ fsp: msg.value.from, endpointType: ENUM.EndPoints.FspEndpointTypes.FSPIOP_CALLBACK_URL_FX_TRANSFER_PUT, id: msg.value.content.payload.commitRequestId, isFx: true, span: undefined })))
+      test.ok(Participant.getEndpoint.getCall(0).calledWith(match({ fsp: msg.value.to, endpointType: ENUM.EndPoints.FspEndpointTypes.FSPIOP_CALLBACK_URL_FX_TRANSFER_PUT, id: msg.value.content.payload.commitRequestId, isFx: true, span: undefined })))
       test.ok(createCallbackHeadersSpy.getCall(0).calledWith(match({ dfspId: msg.value.to, transferId: msg.value.content.payload.commitRequestId, headers: msg.value.content.headers, httpMethod: method, endpointTemplate: ENUM.EndPoints.FspEndpointTemplates.FX_TRANSFERS_PUT })))
       test.ok(createCallbackHeadersSpy.getCall(1).calledWith(match({ dfspId: msg.value.from, transferId: msg.value.content.payload.commitRequestId, headers: msg.value.content.headers, httpMethod: method, endpointTemplate: ENUM.EndPoints.FspEndpointTemplates.FX_TRANSFERS_PUT }), true))
       test.ok(Callback.sendRequest.calledWith(match({ url: toUrl, headers: toHeaders, source: msg.value.from, destination: msg.value.to, method, payload: JSON.stringify(message), hubNameRegex })))
@@ -1695,8 +1695,8 @@ Test('Notification Service tests', async notificationTest => {
 
       const result = await Notification.processMessage(msg)
 
-      test.ok(Participant.getEndpoint.getCall(0).calledWith(match({ fsp: msg.value.from, endpointType: ENUM.EndPoints.FspEndpointTypes.FSPIOP_CALLBACK_URL_TRANSFER_ERROR, id: msg.value.content.payload.transferId, isFx: false, span: undefined })))
-      test.ok(Participant.getEndpoint.getCall(1).calledWith(match({ fsp: msg.value.to, endpointType: ENUM.EndPoints.FspEndpointTypes.FSPIOP_CALLBACK_URL_TRANSFER_ERROR, id: msg.value.content.payload.transferId, isFx: false, span: undefined })))
+      test.ok(Participant.getEndpoint.getCall(1).calledWith(match({ fsp: msg.value.from, endpointType: ENUM.EndPoints.FspEndpointTypes.FSPIOP_CALLBACK_URL_TRANSFER_ERROR, id: msg.value.content.payload.transferId, isFx: false, span: undefined })))
+      test.ok(Participant.getEndpoint.getCall(0).calledWith(match({ fsp: msg.value.to, endpointType: ENUM.EndPoints.FspEndpointTypes.FSPIOP_CALLBACK_URL_TRANSFER_ERROR, id: msg.value.content.payload.transferId, isFx: false, span: undefined })))
       test.ok(createCallbackHeadersSpy.getCall(0).calledWith(match({ dfspId: msg.value.to, transferId: msg.value.content.payload.transferId, headers: msg.value.content.headers, httpMethod: method, endpointTemplate: ENUM.EndPoints.FspEndpointTemplates.TRANSFERS_PUT_ERROR })))
       test.ok(createCallbackHeadersSpy.getCall(1).calledWith(match({ dfspId: msg.value.from, transferId: msg.value.content.payload.transferId, headers: msg.value.content.headers, httpMethod: method, endpointTemplate: ENUM.EndPoints.FspEndpointTemplates.TRANSFERS_PUT_ERROR }), true))
       test.ok(Callback.sendRequest.calledWith(match({ url: toUrl, headers: toHeaders, source: msg.value.from, destination: msg.value.to, method, payload: JSON.stringify(message), hubNameRegex })))


### PR DESCRIPTION
Fix several issues in the code:
- `getEndpoint()` for the `source` is sometimes invoked without being needed, the value returned by that is used only in specific cases;
- getting endpoints for the `source` and `destination` is coupled in a `Promise.all()` call, so failing to obtain one endpoint results in no notifications being sent at all, while it could be sent to the destination;
- failing to send a notification to the destination will prevent sending it to the source too.