### PR TITLE
fix(deps): resolve audit check failures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2289,6 +2289,18 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2500,6 +2512,19 @@
         "node": ">=18.17.0",
         "npm": ">=9.5.0"
       }
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
+      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -6351,9 +6376,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.7",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.7.tgz",
-      "integrity": "sha512-LteOsISQ2GEiDHZch6L9hB0+MLoYVLToR7xotrzU0opCICBkxOPgHAy1HxAvtxfJNXDJpgAsQN30mkrfpO2Prg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.0.tgz",
+      "integrity": "sha512-MTcrUoRQ1GSQ9iG3QJzBGquYYYeA7piZaJoIWbPFGbRn6Jj6z7xgoAyi4DrZX4y2ZIQQBF59gc/zmvvejjgoFQ==",
       "funding": [
         {
           "type": "github",
@@ -6362,9 +6387,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.1.3",
-        "strnum": "^2.2.0"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -16027,13 +16053,17 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/uuid4": {

--- a/package.json
+++ b/package.json
@@ -148,8 +148,9 @@
     "lodash": "4.18.1",
     "lodash-es": ">=4.18.1",
     "undici": ">=7.18.2",
-    "fast-xml-parser": "5.5.7",
+    "fast-xml-parser": "5.7.0",
     "qs": "6.14.2",
+    "uuid": "14.0.0",
     "minimatch@3.0.5": "3.1.5",
     "yaml": "2.8.3"
   },


### PR DESCRIPTION
## Summary

Resolve the current audit check failures in `ml-api-adapter` using local dependency overrides.

## Changes

- bump overridden `fast-xml-parser` from `5.5.7` to `5.7.0`
- add an override for `uuid` to `14.0.0`

## Why

This clears the current failing audit paths:

- `openapi-sampler > fast-xml-parser`
- `nyc > istanbul-lib-processinfo > uuid`

For `uuid`, this change is based on GitHub advisory `GHSA-w5hq-g745-h8pq`, which marks all versions below `14.0.0` as affected and `14.0.0` as the patched version. That means a smaller version bump would not satisfy the advisory.

`uuid` was added as an override instead of updating `nyc` because `ml-api-adapter` is already on the latest published `nyc` release, and the latest published `istanbul-lib-processinfo` still depends on `uuid@^8.3.2`. There is currently no newer upstream `nyc` release available that resolves this advisory path.



## Verification

- `npm install`
- `npm test`
- `npm run audit:check`

## Notes

- `fast-xml-parser` is in the application dependency tree through OpenAPI tooling
- `uuid` is pulled in transitively through coverage tooling: `nyc -> istanbul-lib-processinfo`
- the `uuid` override is a cross-major override, but the full unit suite passed with it in place


## References

- [GHSA-gh4j-gqv2-49f6](https://github.com/advisories/GHSA-gh4j-gqv2-49f6)
- [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq)
- [nyc on npm](https://www.npmjs.com/package/nyc)
- [istanbul-lib-processinfo on npm](https://www.npmjs.com/package/istanbul-lib-processinfo)
