### PR TITLE
feat: make http agent configurable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 setup: true
 orbs:
-  build: mojaloop/build@2.1.0
+  build: mojaloop/build@2.1.1
 workflows:
   setup:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 setup: true
 orbs:
-  build: mojaloop/build@1.1.19
+  build: mojaloop/build@2.1.0
 workflows:
   setup:
     jobs:

--- a/.license-scanner.json
+++ b/.license-scanner.json
@@ -1,0 +1,9 @@
+{
+  "exceptions": {
+    "pause-stream@0.0.11": {
+      "reason": "Dual MIT OR Apache-2.0 (github.com/dominictarr/pause-stream); declared in deprecated array form [\"MIT\",\"Apache2\"], which syft can't parse to SPDX, so it reads as empty.",
+      "expires": "2027-01-01"
+    }
+  }
+}
+

--- a/.ncurc.yaml
+++ b/.ncurc.yaml
@@ -3,4 +3,5 @@ reject: [
     # v6+ (ref: https://github.com/sindresorhus/get-port/releases/tag/v6.0.0) is an ESM library and thus not compatible with CommonJS. Future story needed to resolve.
     # Issue is tracked here: https://github.com/mojaloop/project/issues/3616
     "get-port",
+    "commander",
 ]

--- a/config/default.json
+++ b/config/default.json
@@ -24,6 +24,12 @@
     }
   },
   "HTTP_REQUEST_TIMEOUT_MS": 20000,
+  "HTTP_AGENT": {
+    "KEEP_ALIVE": true,
+    "MAX_SOCKETS": 512,
+    "MAX_FREE_SOCKETS": 512,
+    "KEEP_ALIVE_MSECS": 30000
+  },
   "PORT": 3000,
   "HOSTNAME": "http://ml-api-adapter",
   "ENDPOINT_SOURCE_URL": "http://localhost:3001",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@now-ims/hapi-now-auth": "2.1.0",
         "axios": "1.18.0",
         "blipp": "4.0.2",
-        "commander": "15.0.0",
+        "commander": "14.0.3",
         "docdash": "2.0.2",
         "fast-safe-stringify": "2.1.1",
         "glob": "13.0.6",
@@ -40,7 +40,7 @@
       "devDependencies": {
         "@mojaloop/database-lib": "^11.3.7",
         "@mojaloop/inter-scheme-proxy-cache-lib": "2.10.0",
-        "@mojaloop/license-scanner-tool": "^1.1.0",
+        "@mojaloop/license-scanner-tool": "^1.1.1",
         "audit-ci": "7.1.0",
         "get-port": "5.1.1",
         "jsdoc": "4.0.5",
@@ -1496,15 +1496,6 @@
         "js-yaml": "^4.1.0"
       }
     },
-    "node_modules/@mojaloop/api-snippets/node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      }
-    },
     "node_modules/@mojaloop/central-services-error-handling": {
       "version": "13.1.6",
       "resolved": "https://registry.npmjs.org/@mojaloop/central-services-error-handling/-/central-services-error-handling-13.1.6.tgz",
@@ -1917,9 +1908,9 @@
       }
     },
     "node_modules/@mojaloop/license-scanner-tool": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@mojaloop/license-scanner-tool/-/license-scanner-tool-1.1.0.tgz",
-      "integrity": "sha512-eQfYPJhIL44qMA7RwiwnPOTa/284WqJ//KIZ1TLZeApJApcA10fuDmSKMqlxbv01O+0oeF3tIoHVzP9+h98c5g==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mojaloop/license-scanner-tool/-/license-scanner-tool-1.1.1.tgz",
+      "integrity": "sha512-jP2fSnVR/ngIcyDNqEbUT19+ynwR5mnj8eFZIBFGcxqO16LAZV9tQgZjuV9EGu3dARrvctIDSHyLCIYAAtdKow==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2315,15 +2306,6 @@
       "license": "MIT",
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/@mojaloop/sdk-standard-components/node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
       }
     },
     "node_modules/@mojaloop/sdk-standard-components/node_modules/dotenv": {
@@ -4145,12 +4127,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
-      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "license": "MIT",
       "engines": {
-        "node": ">=22.12.0"
+        "node": ">=20"
       }
     },
     "node_modules/commondir": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,21 +13,21 @@
         "@hapi/boom": "10.0.1",
         "@hapi/good": "9.0.1",
         "@hapi/hapi": "21.4.9",
-        "@hapi/inert": "7.1.0",
+        "@hapi/inert": "7.1.1",
         "@hapi/vision": "7.0.3",
         "@mojaloop/central-services-error-handling": "13.1.6",
         "@mojaloop/central-services-health": "15.2.2",
         "@mojaloop/central-services-logger": "11.10.4",
         "@mojaloop/central-services-metrics": "12.8.5",
-        "@mojaloop/central-services-shared": "18.35.7",
+        "@mojaloop/central-services-shared": "18.37.0",
         "@mojaloop/central-services-stream": "11.9.1",
         "@mojaloop/event-sdk": "14.8.4",
-        "@mojaloop/ml-schema-transformer-lib": "2.9.0",
-        "@mojaloop/sdk-standard-components": "19.18.9",
+        "@mojaloop/ml-schema-transformer-lib": "2.10.0",
+        "@mojaloop/sdk-standard-components": "19.19.0",
         "@now-ims/hapi-now-auth": "2.1.0",
-        "axios": "1.16.0",
+        "axios": "1.18.0",
         "blipp": "4.0.2",
-        "commander": "14.0.3",
+        "commander": "15.0.0",
         "docdash": "2.0.2",
         "fast-safe-stringify": "2.1.1",
         "glob": "13.0.6",
@@ -47,7 +47,7 @@
         "license-checker": "25.0.1",
         "nodemon": "3.1.14",
         "npm-audit-resolver": "3.0.0-RC.0",
-        "npm-check-updates": "22.2.0",
+        "npm-check-updates": "22.2.3",
         "nyc": "18.0.0",
         "pre-commit": "2.0.0",
         "proxyquire": "2.1.3",
@@ -59,7 +59,7 @@
         "supertest": "7.2.2",
         "tap-spec": "5.0.0",
         "tap-xunit": "2.4.1",
-        "tape": "5.9.0",
+        "tape": "5.10.1",
         "tapes": "4.1.0",
         "uuid4": "2.0.3"
       },
@@ -116,12 +116,12 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -130,9 +130,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -140,21 +140,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -188,14 +188,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -205,14 +205,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -242,9 +242,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -252,29 +252,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -284,9 +284,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -294,18 +294,18 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -313,27 +313,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -343,33 +343,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -377,14 +377,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -611,9 +611,9 @@
       "license": "MIT"
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
-      "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/proto-loader": "^0.8.0",
@@ -642,24 +642,23 @@
       }
     },
     "node_modules/@grpc/proto-loader/node_modules/protobufjs": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
-      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -900,9 +899,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@hapi/inert": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/inert/-/inert-7.1.0.tgz",
-      "integrity": "sha512-5X+cl/Ozm0U9uPGGX1dSKhnhTQIf161bH/kkTN9OBVAZKFG+nrj8j/NMj6S1zBBZWmQrkVRNPfCUGrXzB4fCFQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/inert/-/inert-7.1.1.tgz",
+      "integrity": "sha512-vKSTXYbk1cDt7sLdmRIj8CofJRCcjAH9fUCUJViVzqb7Vi+ajUSfz+pAdwwY315BddwGdoXk0H3i94S0JWEKGQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/ammo": "^6.0.1",
@@ -1177,9 +1176,9 @@
       }
     },
     "node_modules/@hapi/wreck": {
-      "version": "18.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-18.1.1.tgz",
-      "integrity": "sha512-UwTeGBfAnB/1mkw4gD6IQGI/bgMu7iGmqgT8K+xxye3z4ZHhCZlmS2wuHBJmENhBJSKqvoYzJ71ds3Xfq4gofQ==",
+      "version": "18.1.2",
+      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-18.1.2.tgz",
+      "integrity": "sha512-3dMnV2pfhQiyEqu8DL3VBmxkdLiRDiiUDuG79Dp+UK1gL9ZxAfDOUhB6k3D5MLqcgJJ1IARyGFhwoc1NITr/pg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
@@ -1419,6 +1418,24 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/@ljharb/now": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@ljharb/now/-/now-1.0.1.tgz",
+      "integrity": "sha512-yRQ3B8l2v4vTLQ2l+4kBu6EsXaX7czuLB7fvUz0vkHHziHje75R2t/0Mm/vIo31tlZVCEvCoXHkNKW+ugv3uSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/@ljharb/resumer": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@ljharb/resumer/-/resumer-0.1.3.tgz",
@@ -1447,19 +1464,19 @@
       }
     },
     "node_modules/@mojaloop/api-snippets": {
-      "version": "18.3.0",
-      "resolved": "https://registry.npmjs.org/@mojaloop/api-snippets/-/api-snippets-18.3.0.tgz",
-      "integrity": "sha512-VZqsteNrMVq7Ra+7OMYN8JFBOMhKLnbq4tDMFnIE4zPFxhCsuTZEgefhFsejijLwOblSqBwFj95zh9PAKlF8fA==",
+      "version": "18.3.2",
+      "resolved": "https://registry.npmjs.org/@mojaloop/api-snippets/-/api-snippets-18.3.2.tgz",
+      "integrity": "sha512-YFKcwrDT7qAKZ1W3QlY1hedZ++Mygm4V2J70jwSrZN1wALjtrnu/4EoPX+N6x1SFQOI6Nhs+MS5WhceHH+AX/w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.1.2",
         "@redocly/openapi-core": "^1.5.0",
-        "commander": "^14.0.2",
+        "commander": "^14.0.3",
         "jest-ts-auto-mock": "^2.1.0",
         "js-yaml": "4.1.1",
         "json-refs": "^3.0.15",
         "openapi-types": "^12.1.3",
-        "openapi-typescript": "^7.10.1",
+        "openapi-typescript": "^7.13.0",
         "ts-auto-mock": "^3.7.4"
       },
       "engines": {
@@ -1476,6 +1493,15 @@
         "@types/json-schema": "^7.0.6",
         "call-me-maybe": "^1.0.1",
         "js-yaml": "^4.1.0"
+      }
+    },
+    "node_modules/@mojaloop/api-snippets/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@mojaloop/central-services-error-handling": {
@@ -1573,32 +1599,32 @@
       }
     },
     "node_modules/@mojaloop/central-services-shared": {
-      "version": "18.35.7",
-      "resolved": "https://registry.npmjs.org/@mojaloop/central-services-shared/-/central-services-shared-18.35.7.tgz",
-      "integrity": "sha512-apAsnfGg9wiIh4giY/ojGrNpySYLBsuweIbAQ28gWCQOmDkJi9YuAEk+8XzVVo8eSLjpgbHpTttugAp60X219Q==",
+      "version": "18.37.0",
+      "resolved": "https://registry.npmjs.org/@mojaloop/central-services-shared/-/central-services-shared-18.37.0.tgz",
+      "integrity": "sha512-77ZA0HrJMiuSqsLIdKlFgSkOyeXJ8liiyeDlkFzP7ghPQ6hpvPc0lcEu+vQvvjqY9IX1swdUq7dQzjp+/rLahA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@hapi/catbox": "12.1.1",
         "@hapi/catbox-memory": "5.0.1",
-        "@hapi/hapi": "21.4.8",
+        "@hapi/hapi": "21.4.9",
         "@hapi/joi-date": "2.0.1",
         "@mojaloop/inter-scheme-proxy-cache-lib": "2.10.0",
         "@opentelemetry/api": "1.9.1",
         "async-exit-hook": "2.0.1",
         "async-retry": "1.3.3",
-        "axios": "1.14.0",
+        "axios": "1.17.0",
         "clone": "2.1.2",
         "convict": "6.2.5",
-        "dotenv": "17.4.1",
+        "dotenv": "17.4.2",
         "env-var": "7.5.0",
         "event-stream": "4.0.1",
         "fast-safe-stringify": "2.1.1",
-        "immutable": "5.1.5",
+        "immutable": "5.1.6",
         "ioredis": "5.6.1",
-        "joi": "18.1.2",
+        "joi": "18.2.1",
         "lodash": "4.18.1",
         "mustache": "4.2.0",
-        "openapi-backend": "5.16.1",
+        "openapi-backend": "5.17.0",
         "raw-body": "3.0.2",
         "rc": "1.2.8",
         "redlock": "5.0.0-beta.2",
@@ -1606,7 +1632,7 @@
         "ulidx": "2.4.1",
         "uuid4": "2.0.3",
         "widdershins": "4.0.1",
-        "yaml": "2.8.3"
+        "yaml": "2.9.0"
       },
       "peerDependencies": {
         "@mojaloop/central-services-error-handling": "13.x.x",
@@ -1677,64 +1703,6 @@
       "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/@mojaloop/central-services-shared/node_modules/@hapi/hapi": {
-      "version": "21.4.8",
-      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-21.4.8.tgz",
-      "integrity": "sha512-l93IrEG4iQyM+yKdngWmkPtajkJGM81yfinmSFmiaNHG+r1fgsWaewwcE1hhsFnqPrVZpU8Y3PiVJMb6uT+01Q==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@hapi/accept": "^6.0.3",
-        "@hapi/ammo": "^6.0.1",
-        "@hapi/boom": "^10.0.1",
-        "@hapi/bounce": "^3.0.2",
-        "@hapi/call": "^9.0.1",
-        "@hapi/catbox": "^12.1.1",
-        "@hapi/catbox-memory": "^6.0.2",
-        "@hapi/heavy": "^8.0.1",
-        "@hapi/hoek": "^11.0.7",
-        "@hapi/mimos": "^7.0.1",
-        "@hapi/podium": "^5.0.2",
-        "@hapi/shot": "^6.0.2",
-        "@hapi/somever": "^4.1.1",
-        "@hapi/statehood": "^8.2.1",
-        "@hapi/subtext": "^8.1.2",
-        "@hapi/teamwork": "^6.0.1",
-        "@hapi/topo": "^6.0.2",
-        "@hapi/validate": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=14.15.0"
-      }
-    },
-    "node_modules/@mojaloop/central-services-shared/node_modules/@hapi/hapi/node_modules/@hapi/boom": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.1.tgz",
-      "integrity": "sha512-ERcCZaEjdH3OgSJlyjVk8pHIFeus91CjKP3v+MpgBNp5IvGzP2l/bRiD78nqYcKPaZdbKkK5vDBVPd2ohHBlsA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@hapi/hoek": "^11.0.2"
-      }
-    },
-    "node_modules/@mojaloop/central-services-shared/node_modules/@hapi/hapi/node_modules/@hapi/catbox-memory": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-6.0.2.tgz",
-      "integrity": "sha512-H1l4ugoFW/ZRkqeFrIo8p1rWN0PA4MDTfu4JmcoNDvnY975o29mqoZblqFTotxNHlEkMPpIiIBJTV+Mbi+aF0g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@hapi/boom": "^10.0.1",
-        "@hapi/hoek": "^11.0.2"
-      }
-    },
-    "node_modules/@mojaloop/central-services-shared/node_modules/@hapi/validate": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-2.0.1.tgz",
-      "integrity": "sha512-NZmXRnrSLK8MQ9y/CMqE9WSspgB9xA41/LlYR0k967aSZebWr4yNrpxIbov12ICwKy4APSlWXZga9jN5p6puPA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@hapi/hoek": "^11.0.2",
-        "@hapi/topo": "^6.0.1"
-      }
-    },
     "node_modules/@mojaloop/central-services-shared/node_modules/@opentelemetry/api": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
@@ -1745,9 +1713,9 @@
       }
     },
     "node_modules/@mojaloop/central-services-shared/node_modules/joi": {
-      "version": "18.1.2",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-18.1.2.tgz",
-      "integrity": "sha512-rF5MAmps5esSlhCA+N1b6IYHDw9j/btzGaqfgie522jS02Ju/HXBxamlXVlKEHAxoMKQL77HWI8jlqWsFuekZA==",
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.2.1.tgz",
+      "integrity": "sha512-2/OKlogiESf2Nh3TFCrRjrr9z1DRHeW0I+KReF67+4J0Ns+8hBtHRmoWAZ2OFU6I5+TWLEe6sVlSdXPjHm5UbQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/address": "^5.1.1",
@@ -1957,49 +1925,63 @@
       }
     },
     "node_modules/@mojaloop/ml-schema-transformer-lib": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@mojaloop/ml-schema-transformer-lib/-/ml-schema-transformer-lib-2.9.0.tgz",
-      "integrity": "sha512-04woEMD9Xgz586ibGJLJJyByLdizRYxCn7e6URedYXAxR46waBdaeVDLQasbXqmH6NTCQ9TmVJV3t5VV/KQQ9w==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@mojaloop/ml-schema-transformer-lib/-/ml-schema-transformer-lib-2.10.0.tgz",
+      "integrity": "sha512-nCUnP700w1qO/meQ6EeKk8qjI5rgyilMZxQfnMZKueNNUiYIXwf9uf5DAHfd8Spqntk3Uf206Zcsz9LEsqNf7A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@apidevtools/swagger-parser": "12.1.0",
-        "@mojaloop/api-snippets": "18.3.0",
-        "@mojaloop/central-services-error-handling": "13.1.5",
-        "@mojaloop/central-services-logger": "11.10.3",
-        "@mojaloop/central-services-shared": "18.35.2",
-        "ajv": "8.17.1",
+        "@mojaloop/api-snippets": "18.3.2",
+        "@mojaloop/central-services-error-handling": "13.1.6",
+        "@mojaloop/central-services-logger": "11.10.4",
+        "@mojaloop/central-services-shared": "18.37.0",
+        "ajv": "8.20.0",
         "fast-safe-stringify": "2.1.1",
         "ilp-packet": "2.2.0",
         "map-transform-cjs": "0.2.0",
         "node-cache": "5.1.2",
-        "openapi-backend": "5.15.0",
+        "openapi-backend": "5.17.0",
         "swagger-parser": "10.0.3"
       },
       "engines": {
-        "node": ">=18.x"
+        "node": ">=20.x"
       },
       "optionalDependencies": {
-        "@rollup/rollup-linux-x64-musl": "4.57.1"
+        "@rollup/rollup-linux-x64-musl": "4.62.0"
       }
     },
-    "node_modules/@mojaloop/ml-schema-transformer-lib/node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "11.9.3",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.9.3.tgz",
-      "integrity": "sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ==",
+    "node_modules/@mojaloop/sdk-standard-components": {
+      "version": "19.19.0",
+      "resolved": "https://registry.npmjs.org/@mojaloop/sdk-standard-components/-/sdk-standard-components-19.19.0.tgz",
+      "integrity": "sha512-W3Tct5oFsdanWCQ/zk8watDpGBhuwzjuUrtKsBLA8m88n1o6fuQVkf2DQcwAV9a9mrFoY/bn76ivu6bcyl0vdg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mojaloop/central-services-logger": "11.10.4",
+        "@mojaloop/ml-number": "^11.4.3",
+        "@mojaloop/ml-schema-transformer-lib": "2.9.0",
+        "axios": "1.16.0",
+        "axios-retry": "4.5.0",
+        "base64url": "3.0.1",
+        "ilp-packet": "3.1.3",
+        "ilp-packet-v1": "2.2.0",
+        "jsonwebtoken": "9.0.3",
+        "jws": "4.0.1",
+        "safe-stable-stringify": "2.5.0"
+      }
+    },
+    "node_modules/@mojaloop/sdk-standard-components/node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
+      "integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
       "license": "MIT",
       "dependencies": {
         "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.15",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
         "js-yaml": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/philsturgeon"
       }
     },
-    "node_modules/@mojaloop/ml-schema-transformer-lib/node_modules/@hapi/catbox-memory": {
+    "node_modules/@mojaloop/sdk-standard-components/node_modules/@hapi/catbox-memory": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-5.0.1.tgz",
       "integrity": "sha512-QWw9nOYJq5PlvChLWV8i6hQHJYfvdqiXdvTupJFh0eqLZ64Xir7mKNi96d5/ZMUAqXPursfNDIDxjFgoEDUqeQ==",
@@ -2009,7 +1991,7 @@
         "@hapi/hoek": "9.x.x"
       }
     },
-    "node_modules/@mojaloop/ml-schema-transformer-lib/node_modules/@hapi/catbox-memory/node_modules/@hapi/boom": {
+    "node_modules/@mojaloop/sdk-standard-components/node_modules/@hapi/catbox-memory/node_modules/@hapi/boom": {
       "version": "9.1.4",
       "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.4.tgz",
       "integrity": "sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==",
@@ -2018,13 +2000,13 @@
         "@hapi/hoek": "9.x.x"
       }
     },
-    "node_modules/@mojaloop/ml-schema-transformer-lib/node_modules/@hapi/catbox-memory/node_modules/@hapi/hoek": {
+    "node_modules/@mojaloop/sdk-standard-components/node_modules/@hapi/catbox-memory/node_modules/@hapi/hoek": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
       "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/@mojaloop/ml-schema-transformer-lib/node_modules/@hapi/hapi": {
+    "node_modules/@mojaloop/sdk-standard-components/node_modules/@hapi/hapi": {
       "version": "21.4.4",
       "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-21.4.4.tgz",
       "integrity": "sha512-vI6JPLR99WZDKI1nriD0qXDPp8sKFkZfNVGrDDZafDQ8jU+3ERMwS0vPac5aGae6yyyoGZGOBiYExw4N8ScSTQ==",
@@ -2053,7 +2035,7 @@
         "node": ">=14.15.0"
       }
     },
-    "node_modules/@mojaloop/ml-schema-transformer-lib/node_modules/@hapi/hapi/node_modules/@hapi/catbox-memory": {
+    "node_modules/@mojaloop/sdk-standard-components/node_modules/@hapi/hapi/node_modules/@hapi/catbox-memory": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-6.0.2.tgz",
       "integrity": "sha512-H1l4ugoFW/ZRkqeFrIo8p1rWN0PA4MDTfu4JmcoNDvnY975o29mqoZblqFTotxNHlEkMPpIiIBJTV+Mbi+aF0g==",
@@ -2063,7 +2045,7 @@
         "@hapi/hoek": "^11.0.2"
       }
     },
-    "node_modules/@mojaloop/ml-schema-transformer-lib/node_modules/@hapi/validate": {
+    "node_modules/@mojaloop/sdk-standard-components/node_modules/@hapi/validate": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-2.0.1.tgz",
       "integrity": "sha512-NZmXRnrSLK8MQ9y/CMqE9WSspgB9xA41/LlYR0k967aSZebWr4yNrpxIbov12ICwKy4APSlWXZga9jN5p6puPA==",
@@ -2073,7 +2055,27 @@
         "@hapi/topo": "^6.0.1"
       }
     },
-    "node_modules/@mojaloop/ml-schema-transformer-lib/node_modules/@mojaloop/central-services-error-handling": {
+    "node_modules/@mojaloop/sdk-standard-components/node_modules/@mojaloop/api-snippets": {
+      "version": "18.3.0",
+      "resolved": "https://registry.npmjs.org/@mojaloop/api-snippets/-/api-snippets-18.3.0.tgz",
+      "integrity": "sha512-VZqsteNrMVq7Ra+7OMYN8JFBOMhKLnbq4tDMFnIE4zPFxhCsuTZEgefhFsejijLwOblSqBwFj95zh9PAKlF8fA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^9.1.2",
+        "@redocly/openapi-core": "^1.5.0",
+        "commander": "^14.0.2",
+        "jest-ts-auto-mock": "^2.1.0",
+        "js-yaml": "4.1.1",
+        "json-refs": "^3.0.15",
+        "openapi-types": "^12.1.3",
+        "openapi-typescript": "^7.10.1",
+        "ts-auto-mock": "^3.7.4"
+      },
+      "engines": {
+        "node": ">=22.x"
+      }
+    },
+    "node_modules/@mojaloop/sdk-standard-components/node_modules/@mojaloop/central-services-error-handling": {
       "version": "13.1.5",
       "resolved": "https://registry.npmjs.org/@mojaloop/central-services-error-handling/-/central-services-error-handling-13.1.5.tgz",
       "integrity": "sha512-iS5BHlexNsvVy98XKORMnv588gbdoomQWDqPMskOoz67iLYFA0Zqlv9wSL/Uyz6PSjP1LF/BwNtX1YKMzich5Q==",
@@ -2083,7 +2085,85 @@
         "lodash": "4.17.21"
       }
     },
-    "node_modules/@mojaloop/ml-schema-transformer-lib/node_modules/@mojaloop/central-services-logger": {
+    "node_modules/@mojaloop/sdk-standard-components/node_modules/@mojaloop/inter-scheme-proxy-cache-lib": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@mojaloop/inter-scheme-proxy-cache-lib/-/inter-scheme-proxy-cache-lib-2.9.0.tgz",
+      "integrity": "sha512-HJliNvKffi3s3kC5UhsMoOVcsB+6diLLi0RV3Kxbx+yAq9wvF/D5GEUmioDd6m7FoghA56W/n8Iayp7axM3H5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mojaloop/central-services-logger": "11.10.1",
+        "ajv": "8.17.1",
+        "convict": "6.2.4",
+        "fast-safe-stringify": "2.1.1",
+        "ioredis": "5.6.1"
+      },
+      "engines": {
+        "node": ">=22.15.0"
+      }
+    },
+    "node_modules/@mojaloop/sdk-standard-components/node_modules/@mojaloop/inter-scheme-proxy-cache-lib/node_modules/@mojaloop/central-services-logger": {
+      "version": "11.10.1",
+      "resolved": "https://registry.npmjs.org/@mojaloop/central-services-logger/-/central-services-logger-11.10.1.tgz",
+      "integrity": "sha512-r6syTKovgPxxtIs5IODq8bO/QrIx7E4pgLXDUp42mXvgngIJDiW0JQ16GCJ7o+RwVqhIKkOsYI/0qtt75NKgCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "1.9.0",
+        "parse-strings-in-object": "2.0.0",
+        "rc": "1.2.8",
+        "safe-stable-stringify": "^2.5.0",
+        "triple-beam": "1.4.1",
+        "winston": "3.17.0"
+      }
+    },
+    "node_modules/@mojaloop/sdk-standard-components/node_modules/@mojaloop/inter-scheme-proxy-cache-lib/node_modules/winston": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.17.0.tgz",
+      "integrity": "sha512-DLiFIXYC5fMPxaRg832S6F5mJYvePtmO5G9v9IgUFPhXm9/GkXarH/TUrBAVzhTCzAj9anE/+GjrgXp/54nOgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.2",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.7.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.9.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@mojaloop/sdk-standard-components/node_modules/@mojaloop/ml-schema-transformer-lib": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@mojaloop/ml-schema-transformer-lib/-/ml-schema-transformer-lib-2.9.0.tgz",
+      "integrity": "sha512-04woEMD9Xgz586ibGJLJJyByLdizRYxCn7e6URedYXAxR46waBdaeVDLQasbXqmH6NTCQ9TmVJV3t5VV/KQQ9w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@apidevtools/swagger-parser": "12.1.0",
+        "@mojaloop/api-snippets": "18.3.0",
+        "@mojaloop/central-services-error-handling": "13.1.5",
+        "@mojaloop/central-services-logger": "11.10.3",
+        "@mojaloop/central-services-shared": "18.35.2",
+        "ajv": "8.17.1",
+        "fast-safe-stringify": "2.1.1",
+        "ilp-packet": "2.2.0",
+        "map-transform-cjs": "0.2.0",
+        "node-cache": "5.1.2",
+        "openapi-backend": "5.15.0",
+        "swagger-parser": "10.0.3"
+      },
+      "engines": {
+        "node": ">=18.x"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-linux-x64-musl": "4.57.1"
+      }
+    },
+    "node_modules/@mojaloop/sdk-standard-components/node_modules/@mojaloop/ml-schema-transformer-lib/node_modules/@mojaloop/central-services-logger": {
       "version": "11.10.3",
       "resolved": "https://registry.npmjs.org/@mojaloop/central-services-logger/-/central-services-logger-11.10.3.tgz",
       "integrity": "sha512-a5ivQqhhiT2X/TkHYTnE00efzCqUiLeik9+YEOoNwYufKeARUx+c0J6Jy8hnyHWE85imX9GklyAIcwrvJBw7og==",
@@ -2097,7 +2177,7 @@
         "winston": "3.19.0"
       }
     },
-    "node_modules/@mojaloop/ml-schema-transformer-lib/node_modules/@mojaloop/central-services-shared": {
+    "node_modules/@mojaloop/sdk-standard-components/node_modules/@mojaloop/ml-schema-transformer-lib/node_modules/@mojaloop/central-services-shared": {
       "version": "18.35.2",
       "resolved": "https://registry.npmjs.org/@mojaloop/central-services-shared/-/central-services-shared-18.35.2.tgz",
       "integrity": "sha512-jM4VxstEmds7TwYpUAGY6NGyzU7+YAyJZaqkdBN2qqBe+/bm+o19FVcnfiJOH5dQ8jGneBQ4sJC2Zz1+otIypA==",
@@ -2171,59 +2251,53 @@
         }
       }
     },
-    "node_modules/@mojaloop/ml-schema-transformer-lib/node_modules/@mojaloop/inter-scheme-proxy-cache-lib": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@mojaloop/inter-scheme-proxy-cache-lib/-/inter-scheme-proxy-cache-lib-2.9.0.tgz",
-      "integrity": "sha512-HJliNvKffi3s3kC5UhsMoOVcsB+6diLLi0RV3Kxbx+yAq9wvF/D5GEUmioDd6m7FoghA56W/n8Iayp7axM3H5g==",
+    "node_modules/@mojaloop/sdk-standard-components/node_modules/@mojaloop/ml-schema-transformer-lib/node_modules/ilp-packet": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ilp-packet/-/ilp-packet-2.2.0.tgz",
+      "integrity": "sha512-QEGqY0HzGrue4r+4GWWe7lB7Xvjij4cyc2XeOTHYmwkO0BjgwzJW85mZJzR9q5HmK8zdFkN6C0CfedAaYiUv9w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mojaloop/central-services-logger": "11.10.1",
-        "ajv": "8.17.1",
-        "convict": "6.2.4",
-        "fast-safe-stringify": "2.1.1",
-        "ioredis": "5.6.1"
-      },
-      "engines": {
-        "node": ">=22.15.0"
+        "bignumber.js": "^5.0.0",
+        "extensible-error": "^1.0.2",
+        "long": "^3.2.0",
+        "oer-utils": "^1.3.2"
       }
     },
-    "node_modules/@mojaloop/ml-schema-transformer-lib/node_modules/@mojaloop/inter-scheme-proxy-cache-lib/node_modules/@mojaloop/central-services-logger": {
-      "version": "11.10.1",
-      "resolved": "https://registry.npmjs.org/@mojaloop/central-services-logger/-/central-services-logger-11.10.1.tgz",
-      "integrity": "sha512-r6syTKovgPxxtIs5IODq8bO/QrIx7E4pgLXDUp42mXvgngIJDiW0JQ16GCJ7o+RwVqhIKkOsYI/0qtt75NKgCw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "1.9.0",
-        "parse-strings-in-object": "2.0.0",
-        "rc": "1.2.8",
-        "safe-stable-stringify": "^2.5.0",
-        "triple-beam": "1.4.1",
-        "winston": "3.17.0"
-      }
-    },
-    "node_modules/@mojaloop/ml-schema-transformer-lib/node_modules/@mojaloop/inter-scheme-proxy-cache-lib/node_modules/winston": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.17.0.tgz",
-      "integrity": "sha512-DLiFIXYC5fMPxaRg832S6F5mJYvePtmO5G9v9IgUFPhXm9/GkXarH/TUrBAVzhTCzAj9anE/+GjrgXp/54nOgw==",
+    "node_modules/@mojaloop/sdk-standard-components/node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
+      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
-      "dependencies": {
-        "@colors/colors": "^1.6.0",
-        "@dabh/diagnostics": "^2.0.2",
-        "async": "^3.2.3",
-        "is-stream": "^2.0.0",
-        "logform": "^2.7.0",
-        "one-time": "^1.0.0",
-        "readable-stream": "^3.4.0",
-        "safe-stable-stringify": "^2.3.1",
-        "stack-trace": "0.0.x",
-        "triple-beam": "^1.3.0",
-        "winston-transport": "^4.9.0"
-      },
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@mojaloop/sdk-standard-components/node_modules/bignumber.js": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-5.0.0.tgz",
+      "integrity": "sha512-KWTu6ZMVk9sxlDJQh2YH1UOnfDP8O8TpxUxgQG/vKASoSnEjK9aVuOueFaPcQEYQ5fyNXNTOYwYw3099RYebWg==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 12.0.0"
+        "node": "*"
       }
     },
-    "node_modules/@mojaloop/ml-schema-transformer-lib/node_modules/dotenv": {
+    "node_modules/@mojaloop/sdk-standard-components/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@mojaloop/sdk-standard-components/node_modules/dotenv": {
       "version": "17.2.3",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
       "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
@@ -2235,10 +2309,35 @@
         "url": "https://dotenvx.com"
       }
     },
-    "node_modules/@mojaloop/ml-schema-transformer-lib/node_modules/joi": {
-      "version": "18.0.2",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-18.0.2.tgz",
-      "integrity": "sha512-RuCOQMIt78LWnktPoeBL0GErkNaJPTBGcYuyaBvUOQSpcpcLfWrHPPihYdOGbV5pam9VTWbeoF7TsGiHugcjGA==",
+    "node_modules/@mojaloop/sdk-standard-components/node_modules/ilp-packet": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/ilp-packet/-/ilp-packet-3.1.3.tgz",
+      "integrity": "sha512-FBsiPQbHPdLPI6jdA+sQO+4fFBuMc212yCdNXMqoGJdic2GFHF/E8P9bTorIVRZRVExhWDE5givqCMguupW8VA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extensible-error": "^1.0.2",
+        "oer-utils": "^5.1.2"
+      }
+    },
+    "node_modules/@mojaloop/sdk-standard-components/node_modules/ilp-packet/node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@mojaloop/sdk-standard-components/node_modules/ilp-packet/node_modules/oer-utils": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/oer-utils/-/oer-utils-5.1.2.tgz",
+      "integrity": "sha512-VhkvT3bthHrbnwBOG9vGpDFB8XHrIitpZY2nC+3scZI2Tf17g8YmeDK6wsA7HpdjGXMsbf14fRgltBXwhzrWOw==",
+      "dependencies": {
+        "@types/long": "4.0.1",
+        "long": "^4.0.0"
+      }
+    },
+    "node_modules/@mojaloop/sdk-standard-components/node_modules/joi": {
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.2.1.tgz",
+      "integrity": "sha512-2/OKlogiESf2Nh3TFCrRjrr9z1DRHeW0I+KReF67+4J0Ns+8hBtHRmoWAZ2OFU6I5+TWLEe6sVlSdXPjHm5UbQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/address": "^5.1.1",
@@ -2247,13 +2346,22 @@
         "@hapi/pinpoint": "^2.0.1",
         "@hapi/tlds": "^1.1.1",
         "@hapi/topo": "^6.0.2",
-        "@standard-schema/spec": "^1.0.0"
+        "@standard-schema/spec": "^1.1.0"
       },
       "engines": {
         "node": ">= 20"
       }
     },
-    "node_modules/@mojaloop/ml-schema-transformer-lib/node_modules/openapi-backend": {
+    "node_modules/@mojaloop/sdk-standard-components/node_modules/long": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
+      "integrity": "sha512-ZYvPPOMqUwPoDsbJaR10iQJYnMuZhRTvHYl62ErLIEX7RgFlziSBUUvrt3OVfc47QlHHpzPZYP17g3Fv7oeJkg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/@mojaloop/sdk-standard-components/node_modules/openapi-backend": {
       "version": "5.15.0",
       "resolved": "https://registry.npmjs.org/openapi-backend/-/openapi-backend-5.15.0.tgz",
       "integrity": "sha512-yox0nCv511YWUeBNCdKY6xmUB92yEN+N9rHO4BHA5GOAZaNtY+zzuftAdfEwIbCsCcvZJ9ysENCguqBg+hLlWw==",
@@ -2277,7 +2385,24 @@
         "url": "https://github.com/sponsors/anttiviljami"
       }
     },
-    "node_modules/@mojaloop/ml-schema-transformer-lib/node_modules/readable-stream": {
+    "node_modules/@mojaloop/sdk-standard-components/node_modules/openapi-backend/node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "11.9.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.9.3.tgz",
+      "integrity": "sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
+      }
+    },
+    "node_modules/@mojaloop/sdk-standard-components/node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
@@ -2289,50 +2414,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/@mojaloop/sdk-standard-components": {
-      "version": "19.18.9",
-      "resolved": "https://registry.npmjs.org/@mojaloop/sdk-standard-components/-/sdk-standard-components-19.18.9.tgz",
-      "integrity": "sha512-5M+z2rvppUxb+2hceucNL2C99bPlJE8fj6njr5eEjphAckhBrarQh/l5Sqd7ztm7euokvCiRWk1T/QouMhK2HQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mojaloop/central-services-logger": "11.10.4",
-        "@mojaloop/ml-number": "^11.4.3",
-        "@mojaloop/ml-schema-transformer-lib": "2.9.0",
-        "axios": "1.15.0",
-        "axios-retry": "4.5.0",
-        "base64url": "3.0.1",
-        "ilp-packet": "3.1.3",
-        "ilp-packet-v1": "2.2.0",
-        "jsonwebtoken": "9.0.3",
-        "jws": "4.0.1",
-        "safe-stable-stringify": "2.5.0"
-      }
-    },
-    "node_modules/@mojaloop/sdk-standard-components/node_modules/ilp-packet": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/ilp-packet/-/ilp-packet-3.1.3.tgz",
-      "integrity": "sha512-FBsiPQbHPdLPI6jdA+sQO+4fFBuMc212yCdNXMqoGJdic2GFHF/E8P9bTorIVRZRVExhWDE5givqCMguupW8VA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "extensible-error": "^1.0.2",
-        "oer-utils": "^5.1.2"
-      }
-    },
-    "node_modules/@mojaloop/sdk-standard-components/node_modules/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@mojaloop/sdk-standard-components/node_modules/oer-utils": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/oer-utils/-/oer-utils-5.1.2.tgz",
-      "integrity": "sha512-VhkvT3bthHrbnwBOG9vGpDFB8XHrIitpZY2nC+3scZI2Tf17g8YmeDK6wsA7HpdjGXMsbf14fRgltBXwhzrWOw==",
-      "dependencies": {
-        "@types/long": "4.0.1",
-        "long": "^4.0.0"
       }
     },
     "node_modules/@noble/hashes": {
@@ -2477,37 +2558,30 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "^1.1.1"
       }
     },
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -2523,9 +2597,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@redocly/ajv": {
@@ -2551,9 +2625,9 @@
       "license": "MIT"
     },
     "node_modules/@redocly/openapi-core": {
-      "version": "1.34.12",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.12.tgz",
-      "integrity": "sha512-b32XWsz6enN6K4bx8xWsqUaXTJR/DnYT3lL1CzDYzIYKw243NNlz6fexmr71q/U4HrEcMoJGBvwAfcxOb8ymQw==",
+      "version": "1.34.15",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.15.tgz",
+      "integrity": "sha512-HAwCnNyKcs5XGQqms+9t7OdAPM/5TDstmhF+0i7tdCFato2QKuYIlyWETwkXd8c5zbltr1oB+6y9NTeQLr2d6Q==",
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "8.11.2",
@@ -2572,9 +2646,9 @@
       }
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
-      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.0.tgz",
+      "integrity": "sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw==",
       "cpu": [
         "x64"
       ],
@@ -2769,6 +2843,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "deprecated": "Potential CWE-502 - Update to 1.3.1 or higher",
       "dev": true,
       "license": "ISC"
     },
@@ -3334,13 +3409,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
-      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+      "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -3354,6 +3430,31 @@
       },
       "peerDependencies": {
         "axios": "0.x || 1.x"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/balanced-match": {
@@ -3375,9 +3476,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.20",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.20.tgz",
-      "integrity": "sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==",
+      "version": "2.10.37",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz",
+      "integrity": "sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3455,9 +3556,9 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -3468,7 +3569,7 @@
         "http-errors": "~2.0.1",
         "iconv-lite": "~0.4.24",
         "on-finished": "~2.4.1",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
         "unpipe": "~1.0.0"
@@ -3527,9 +3628,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -3738,9 +3839,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001788",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
-      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "dev": true,
       "funding": [
         {
@@ -4015,12 +4116,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/commondir": {
@@ -5063,9 +5164,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.4.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.1.tgz",
-      "integrity": "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -5266,9 +5367,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.343",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.343.tgz",
-      "integrity": "sha512-YHnQ3MXI08icvL9ZKnEBy05F2EQ8ob01UaMOuMbM8l+4UcAq6MPPbBTJBbsBUg3H8JeZNt+O4fjsoWth3p6IFg==",
+      "version": "1.5.372",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.372.tgz",
+      "integrity": "sha512-M3yhbAlilnwqC8D21t28UCDGHyitShTmmLRU/H+b74P6Ski16Nb9HONYEaVpMj/pwC7BEo5B95FpjODLCWbtfA==",
       "dev": true,
       "license": "ISC"
     },
@@ -5511,9 +5612,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -6305,14 +6406,14 @@
       }
     },
     "node_modules/express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
+        "body-parser": "~1.20.5",
         "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
         "cookie": "~0.7.1",
@@ -6331,7 +6432,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "~0.19.0",
@@ -6728,16 +6829,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -7617,9 +7718,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -8262,12 +8363,12 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8908,9 +9009,9 @@
       "license": "MIT"
     },
     "node_modules/joi": {
-      "version": "17.13.3",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
-      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+      "version": "17.13.4",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.4.tgz",
+      "integrity": "sha512-1RuuER6kmt8K8I3nIWvPZKi5RQCb568ZPyY4Pwjlua+yo+63ZTmIwxLZH0heBmiKN4uxjvCiarDrjaeH84xicQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/hoek": "^9.3.0",
@@ -8951,9 +9052,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -9552,10 +9663,19 @@
       "license": "MIT"
     },
     "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
-      "dev": true,
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
@@ -9844,15 +9964,24 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
-      "dev": true,
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
+        "linkify-it": "^5.0.1",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"
@@ -9870,6 +9999,18 @@
       "peerDependencies": {
         "@types/markdown-it": "*",
         "markdown-it": "*"
+      }
+    },
+    "node_modules/markdown-it-attrs": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/markdown-it-attrs/-/markdown-it-attrs-1.2.1.tgz",
+      "integrity": "sha512-EYYKLF9RvQJx1Etsb6EsBGWL7qNQLpg9BRej5f06+UdX75T5gvldEn7ts6bkLIQqugE15SGn4lw1CXDS1A+XUA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "markdown-it": ">=7.0.1"
       }
     },
     "node_modules/markdown-it-emoji": {
@@ -9910,7 +10051,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/media-typer": {
@@ -10626,11 +10766,14 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.38",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
-      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "version": "2.0.47",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/nodemon": {
       "version": "3.1.14",
@@ -10770,9 +10913,9 @@
       }
     },
     "node_modules/npm-check-updates": {
-      "version": "22.2.0",
-      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-22.2.0.tgz",
-      "integrity": "sha512-kaxgbkGkCOtoSrsUXShgcEiEfrRPqmOGk6Yeya+5hoNptblu9vuE8/PLABUSJz+IeNgKJBFxcC3UrBYmKsB8iA==",
+      "version": "22.2.3",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-22.2.3.tgz",
+      "integrity": "sha512-n8HZ0ywZugYRgEqIm67hbZC5L/9S/gLX+MkGchJB43pP2xib1+u76OpVEJRZ4QP2BksPRi5M1CCStJVfc16+/A==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -11187,9 +11330,9 @@
       }
     },
     "node_modules/openapi-backend": {
-      "version": "5.16.1",
-      "resolved": "https://registry.npmjs.org/openapi-backend/-/openapi-backend-5.16.1.tgz",
-      "integrity": "sha512-1tfLpC+7CajKv08vuFOLm4t8rJvJyqKuyau5IIIrGg3YuQYhmP7JqDL6p6WnbDCusmh3krCrKXoHB6hLF/iHcQ==",
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/openapi-backend/-/openapi-backend-5.17.0.tgz",
+      "integrity": "sha512-wyimPBoz/Gx+pqh4QwvMQRIJiZQHZkLdiyFXwfjiLwS5Jhbm7gCI+T0WTXmx7HXAYXL5Cr+016dR3CV3T/dPmQ==",
       "license": "MIT",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^11.1.0",
@@ -12067,24 +12210,12 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.0.1.tgz",
-      "integrity": "sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==",
-      "hasInstallScript": true,
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.6.0.tgz",
+      "integrity": "sha512-PIOO89BMGMXGz2333TVv/OqPNVWm7w30ll/4FtLbtLBaonzJMYwTbAZSSlobjIy9MoUgIAxSVUpK7aP7EpTtkg==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -12165,7 +12296,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
       "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -12184,9 +12314,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -13460,58 +13590,6 @@
         "wordwrap": "0.0.2"
       }
     },
-    "node_modules/shins/node_modules/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
-      "license": "BSD-2-Clause",
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/shins/node_modules/linkify-it": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
-      "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
-      "license": "MIT",
-      "dependencies": {
-        "uc.micro": "^1.0.1"
-      }
-    },
-    "node_modules/shins/node_modules/markdown-it": {
-      "version": "12.3.2",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
-      "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1",
-        "entities": "~2.1.0",
-        "linkify-it": "^3.0.1",
-        "mdurl": "^1.0.1",
-        "uc.micro": "^1.0.5"
-      },
-      "bin": {
-        "markdown-it": "bin/markdown-it.js"
-      }
-    },
-    "node_modules/shins/node_modules/markdown-it-attrs": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/markdown-it-attrs/-/markdown-it-attrs-1.2.1.tgz",
-      "integrity": "sha512-EYYKLF9RvQJx1Etsb6EsBGWL7qNQLpg9BRej5f06+UdX75T5gvldEn7ts6bkLIQqugE15SGn4lw1CXDS1A+XUA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "peerDependencies": {
-        "markdown-it": ">=7.0.1"
-      }
-    },
-    "node_modules/shins/node_modules/mdurl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
-      "license": "MIT"
-    },
     "node_modules/shins/node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -13520,12 +13598,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/shins/node_modules/uc.micro": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
-      "license": "MIT"
     },
     "node_modules/shins/node_modules/uglify-js": {
       "version": "2.8.29",
@@ -14755,19 +14827,20 @@
       }
     },
     "node_modules/string.prototype.trim": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
-      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.11.tgz",
+      "integrity": "sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
         "define-data-property": "^1.1.4",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.5",
-        "es-object-atoms": "^1.0.0",
-        "has-property-descriptors": "^1.0.2"
+        "es-abstract": "^1.24.2",
+        "es-object-atoms": "^1.1.2",
+        "has-property-descriptors": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -15374,34 +15447,37 @@
       }
     },
     "node_modules/tape": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/tape/-/tape-5.9.0.tgz",
-      "integrity": "sha512-czbGgxSVwRlbB3Ly/aqQrNwrDAzKHDW/kVXegp4hSFmR2c8qqm3hCgZbUy1+3QAQFGhPDG7J56UsV1uNilBFCA==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-5.10.1.tgz",
+      "integrity": "sha512-cre3VCO4HIc7PSodPWwdLfX1RLUw0IAMVQV8M+erGkLKJ2N2lyxVVqSdRCJL2xM/6o3/3xxwv/QwYr7bRHSquA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@ljharb/now": "^1.0.1",
         "@ljharb/resumer": "^0.1.3",
-        "@ljharb/through": "^2.3.13",
-        "array.prototype.every": "^1.1.6",
-        "call-bind": "^1.0.7",
+        "@ljharb/through": "^2.3.14",
+        "array.prototype.every": "^1.1.7",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
         "deep-equal": "^2.2.3",
         "defined": "^1.0.1",
         "dotignore": "^0.1.2",
-        "for-each": "^0.3.3",
+        "es-object-atoms": "^1.1.2",
+        "for-each": "^0.3.5",
         "get-package-type": "^0.1.0",
         "glob": "^7.2.3",
-        "has-dynamic-import": "^2.1.0",
-        "hasown": "^2.0.2",
+        "has-dynamic-import": "^2.1.1",
+        "hasown": "^2.0.4",
         "inherits": "^2.0.4",
-        "is-regex": "^1.1.4",
+        "is-regex": "^1.2.1",
         "minimist": "^1.2.8",
         "mock-property": "^1.1.0",
-        "object-inspect": "^1.13.2",
+        "object-inspect": "^1.13.4",
         "object-is": "^1.1.6",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.5",
-        "resolve": "^2.0.0-next.5",
-        "string.prototype.trim": "^1.2.9"
+        "object.assign": "^4.1.7",
+        "resolve": "^2.0.0-next.7",
+        "string.prototype.trim": "^1.2.11"
       },
       "bin": {
         "tape": "bin/tape"
@@ -15446,14 +15522,14 @@
       }
     },
     "node_modules/tape/node_modules/resolve": {
-      "version": "2.0.0-next.6",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
-      "integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
+      "version": "2.0.0-next.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
+      "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "is-core-module": "^2.16.1",
+        "is-core-module": "^2.16.2",
         "node-exports-info": "^1.6.0",
         "object-keys": "^1.1.1",
         "path-parse": "^1.0.7",
@@ -15939,7 +16015,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/uglify-js": {
@@ -16395,15 +16470,6 @@
         "wrap-ansi": "^2.0.0"
       }
     },
-    "node_modules/widdershins/node_modules/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
-      "license": "BSD-2-Clause",
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/widdershins/node_modules/find-up": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -16431,15 +16497,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/widdershins/node_modules/linkify-it": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
-      "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
-      "license": "MIT",
-      "dependencies": {
-        "uc.micro": "^1.0.1"
-      }
-    },
     "node_modules/widdershins/node_modules/locate-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -16452,28 +16509,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/widdershins/node_modules/markdown-it": {
-      "version": "12.3.2",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
-      "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1",
-        "entities": "~2.1.0",
-        "linkify-it": "^3.0.1",
-        "mdurl": "^1.0.1",
-        "uc.micro": "^1.0.5"
-      },
-      "bin": {
-        "markdown-it": "bin/markdown-it.js"
-      }
-    },
-    "node_modules/widdershins/node_modules/mdurl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
-      "license": "MIT"
     },
     "node_modules/widdershins/node_modules/p-locate": {
       "version": "3.0.0",
@@ -16526,12 +16561,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/widdershins/node_modules/uc.micro": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
-      "license": "MIT"
     },
     "node_modules/widdershins/node_modules/wrap-ansi": {
       "version": "2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
       "devDependencies": {
         "@mojaloop/database-lib": "^11.3.7",
         "@mojaloop/inter-scheme-proxy-cache-lib": "2.10.0",
+        "@mojaloop/license-scanner-tool": "^1.1.0",
         "audit-ci": "7.1.0",
         "get-port": "5.1.1",
         "jsdoc": "4.0.5",
@@ -64,7 +65,7 @@
         "uuid4": "2.0.3"
       },
       "engines": {
-        "node": ">=18.x"
+        "node": ">=20.x"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
@@ -1913,6 +1914,34 @@
       },
       "engines": {
         "node": ">=22.15.0"
+      }
+    },
+    "node_modules/@mojaloop/license-scanner-tool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mojaloop/license-scanner-tool/-/license-scanner-tool-1.1.0.tgz",
+      "integrity": "sha512-eQfYPJhIL44qMA7RwiwnPOTa/284WqJ//KIZ1TLZeApJApcA10fuDmSKMqlxbv01O+0oeF3tIoHVzP9+h98c5g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-expression-parse": "4.0.0",
+        "spdx-license-ids": "3.0.23"
+      },
+      "bin": {
+        "license-scanner-tool": "src/cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@mojaloop/license-scanner-tool/node_modules/spdx-expression-parse": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
+      "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "node_modules/@mojaloop/ml-number": {

--- a/package.json
+++ b/package.json
@@ -20,13 +20,14 @@
     "url": "git@github.com:mojaloop/ml-api-adapter.git"
   },
   "engines": {
-    "node": ">=18.x"
+    "node": ">=20.x"
   },
   "pre-commit": [
     "lint",
     "test",
     "dep:check",
-    "audit:check"
+    "audit:check",
+    "license:check"
   ],
   "scripts": {
     "start": "npm run start:api",
@@ -166,6 +167,7 @@
   "devDependencies": {
     "@mojaloop/database-lib": "^11.3.7",
     "@mojaloop/inter-scheme-proxy-cache-lib": "2.10.0",
+    "@mojaloop/license-scanner-tool": "^1.1.0",
     "audit-ci": "7.1.0",
     "get-port": "5.1.1",
     "jsdoc": "4.0.5",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@now-ims/hapi-now-auth": "2.1.0",
     "axios": "1.18.0",
     "blipp": "4.0.2",
-    "commander": "15.0.0",
+    "commander": "14.0.3",
     "docdash": "2.0.2",
     "fast-safe-stringify": "2.1.1",
     "glob": "13.0.6",
@@ -167,7 +167,7 @@
   "devDependencies": {
     "@mojaloop/database-lib": "^11.3.7",
     "@mojaloop/inter-scheme-proxy-cache-lib": "2.10.0",
-    "@mojaloop/license-scanner-tool": "^1.1.0",
+    "@mojaloop/license-scanner-tool": "^1.1.1",
     "audit-ci": "7.1.0",
     "get-port": "5.1.1",
     "jsdoc": "4.0.5",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "audit:fix": "npm audit fix",
     "audit:check": "npx audit-ci --config ./audit-ci.jsonc",
     "license:list": "license-checker . --excludePackages `cat .licenseignore | grep '^[^#;]' | awk 'BEGIN { ORS=\"\" } { print p$0\";\"; } END { print \n }'` --production --csv",
-    "license:check": "npm run license:list -- --failOn `cat .licensebanned | grep '^[^#;]' | awk 'BEGIN { ORS=\"\" } { print p$0\";\"; } END { print \n }'`",
+    "license:check": "npx @mojaloop/license-scanner-tool .",
     "dep:check": "npx ncu -e 2",
     "dep:update": "npx ncu -u",
     "release": "npx standard-version --no-verify --releaseCommitMessageFormat 'chore(release): {{currentTag}} [skip ci]'",
@@ -71,21 +71,21 @@
     "@hapi/boom": "10.0.1",
     "@hapi/good": "9.0.1",
     "@hapi/hapi": "21.4.9",
-    "@hapi/inert": "7.1.0",
+    "@hapi/inert": "7.1.1",
     "@hapi/vision": "7.0.3",
     "@mojaloop/central-services-error-handling": "13.1.6",
     "@mojaloop/central-services-health": "15.2.2",
     "@mojaloop/central-services-logger": "11.10.4",
     "@mojaloop/central-services-metrics": "12.8.5",
-    "@mojaloop/central-services-shared": "18.35.7",
+    "@mojaloop/central-services-shared": "18.37.0",
     "@mojaloop/central-services-stream": "11.9.1",
     "@mojaloop/event-sdk": "14.8.4",
-    "@mojaloop/ml-schema-transformer-lib": "2.9.0",
-    "@mojaloop/sdk-standard-components": "19.18.9",
+    "@mojaloop/ml-schema-transformer-lib": "2.10.0",
+    "@mojaloop/sdk-standard-components": "19.19.0",
     "@now-ims/hapi-now-auth": "2.1.0",
-    "axios": "1.16.0",
+    "axios": "1.18.0",
     "blipp": "4.0.2",
-    "commander": "14.0.3",
+    "commander": "15.0.0",
     "docdash": "2.0.2",
     "fast-safe-stringify": "2.1.1",
     "glob": "13.0.6",
@@ -96,6 +96,8 @@
     "rc": "1.2.8"
   },
   "overrides": {
+    "@hapi/wreck": "18.1.2",
+    "@grpc/grpc-js": "1.14.4",
     "@mojaloop/central-services-shared": {
       "ajv": "8.18.0",
       "@mojaloop/inter-scheme-proxy-cache-lib": {
@@ -106,6 +108,7 @@
       "ajv": "8.18.0",
       "@mojaloop/central-services-shared": {
         "ajv": "8.18.0",
+        "joi": "18.2.1",
         "@mojaloop/inter-scheme-proxy-cache-lib": {
           "ajv": "8.18.0"
         }
@@ -117,30 +120,27 @@
         "ajv": "8.18.0"
       }
     },
-    "axios": "1.16.0",
-    "brace-expansion": "5.0.5",
+    "axios": "1.18.0",
+    "brace-expansion": "5.0.6",
     "convict": "6.2.5",
-    "form-data": "4.0.4",
+    "form-data": "4.0.6",
     "immutable": "5.1.5",
     "on-headers": "1.1.0",
     "path-to-regexp": "0.1.13",
-    "markdown-it": "14.1.1",
+    "markdown-it": "14.2.0",
     "postcss": "8.5.10",
     "shins": {
       "sanitize-html": "2.12.1",
       "jsonpointer": "5.0.0",
-      "markdown-it": "12.3.2",
       "ajv": "8.18.0",
       "ejs": "3.1.10"
     },
     "widdershins": {
-      "swagger2openapi": "7.0.8",
-      "markdown-it": "12.3.2"
+      "swagger2openapi": "7.0.8"
     },
     "jsonwebtoken": "9.0.0",
     "jsonpointer": "5.0.0",
     "cross-spawn": "7.0.6",
-    "protobufjs": "8.0.1",
     "trim": "0.0.3",
     "yargs-parser": "21.1.1",
     "js-yaml": ">=4.1.1",
@@ -152,14 +152,14 @@
     "fast-xml-parser": "5.7.0",
     "fast-uri": "3.1.2",
     "fast-xml-builder": "1.1.7",
-    "qs": "6.14.2",
+    "qs": "6.15.2",
     "minimatch@3.0.5": "3.1.5",
     "yaml": "2.8.3",
+    "@grpc/proto-loader": {
+      "protobufjs": "7.6.4"
+    },
     "@mojaloop/event-sdk": {
-      "protobufjs": "8.0.1",
-      "@grpc/proto-loader": {
-        "protobufjs": "7.5.5"
-      }
+      "protobufjs": "8.6.0"
     },
     "uuid": "14.0.0"
   },
@@ -173,7 +173,7 @@
     "license-checker": "25.0.1",
     "nodemon": "3.1.14",
     "npm-audit-resolver": "3.0.0-RC.0",
-    "npm-check-updates": "22.2.0",
+    "npm-check-updates": "22.2.3",
     "nyc": "18.0.0",
     "pre-commit": "2.0.0",
     "proxyquire": "2.1.3",
@@ -185,7 +185,7 @@
     "supertest": "7.2.2",
     "tap-spec": "5.0.0",
     "tap-xunit": "2.4.1",
-    "tape": "5.9.0",
+    "tape": "5.10.1",
     "tapes": "4.1.0",
     "uuid4": "2.0.3"
   },

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -31,6 +31,17 @@ const DEFAULT_PROTOCOL_VERSION = {
   }
 }
 
+const wireHttpAgentEnv = (httpAgent = {}) => {
+  const setEnv = (name, value) => {
+    if (value !== undefined && value !== null) process.env[name] ??= String(value)
+  }
+  setEnv('HTTP_AGENT_KEEP_ALIVE', httpAgent.KEEP_ALIVE)
+  setEnv('HTTP_AGENT_MAX_SOCKETS', httpAgent.MAX_SOCKETS)
+  setEnv('HTTP_AGENT_MAX_FREE_SOCKETS', httpAgent.MAX_FREE_SOCKETS)
+  setEnv('HTTP_AGENT_KEEP_ALIVE_MSECS', httpAgent.KEEP_ALIVE_MSECS)
+}
+wireHttpAgentEnv(RC.HTTP_AGENT)
+
 const getProtocolVersions = (defaultProtocolVersions, overrideProtocolVersions) => {
   const T_PROTOCOL_VERSION = {
     ...defaultProtocolVersions,
@@ -76,6 +87,7 @@ const config = {
   HUB_NAME: RC.HUB_PARTICIPANT.NAME,
   HOSTNAME: RC.HOSTNAME.replace(/\/$/, ''),
   HTTP_REQUEST_TIMEOUT_MS: RC.HTTP_REQUEST_TIMEOUT_MS || 20000,
+  HTTP_AGENT: RC.HTTP_AGENT,
   PORT: RC.PORT,
   AMOUNT: RC.AMOUNT,
   DFSP_URLS: RC.DFSP_URLS,

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -33,7 +33,7 @@ const DEFAULT_PROTOCOL_VERSION = {
 
 const wireHttpAgentEnv = (httpAgent = {}) => {
   const setEnv = (name, value) => {
-    if (value !== undefined && value !== null) process.env[name] ??= String(value)
+    if (value != null) process.env[name] ??= String(value)
   }
   setEnv('HTTP_AGENT_KEEP_ALIVE', httpAgent.KEEP_ALIVE)
   setEnv('HTTP_AGENT_MAX_SOCKETS', httpAgent.MAX_SOCKETS)

--- a/src/lib/healthCheck/subServiceHealth.js
+++ b/src/lib/healthCheck/subServiceHealth.js
@@ -21,13 +21,13 @@
 
  * Mojaloop Foundation
  - Name Surname <name.surname@mojaloop.io>
+ - Shashikant Hirugade <shashi.mojaloop@gmail.com>
 
  * Lewis Daly <lewis@vesselstech.com>
  --------------
  ******/
 'use strict'
 
-const http = require('node:http')
 const axios = require('axios')
 const Producer = require('@mojaloop/central-services-stream').Util.Producer
 const { statusEnum, serviceName } = require('@mojaloop/central-services-shared').HealthCheck.HealthCheckEnums
@@ -35,7 +35,9 @@ const { logger } = require('../../shared/logger')
 const Config = require('../../lib/config')
 const Notification = require('../../handlers/notification')
 
-axios.defaults.httpAgent = new http.Agent({ keepAlive: true })
+// NOTE: do not set axios.defaults.httpAgent here. axios is deduped to a single instance,
+// so central-services-shared (required above) already installs bounded http/https agents on
+// these shared defaults; overriding httpAgent here would clobber them with an unbounded pool.
 
 /**
  * @function getSubServiceHealthBroker

--- a/test/unit/lib/config.test.js
+++ b/test/unit/lib/config.test.js
@@ -182,5 +182,54 @@ Test('Config tests', configTest => {
     test.end()
   })
 
+  configTest.test('HTTP_AGENT config', httpAgentTest => {
+    const AGENT_ENV = ['HTTP_AGENT_KEEP_ALIVE', 'HTTP_AGENT_MAX_SOCKETS', 'HTTP_AGENT_MAX_FREE_SOCKETS', 'HTTP_AGENT_KEEP_ALIVE_MSECS']
+    const clearAgentEnv = () => AGENT_ENV.forEach(k => delete process.env[k])
+
+    httpAgentTest.test('wires HTTP_AGENT_* env vars from config when set', test => {
+      clearAgentEnv()
+      try {
+        const DefaultStub = Util.clone(Default)
+        DefaultStub.ENDPOINT_SECURITY.JWS.JWS_SIGN = false
+        DefaultStub.HTTP_AGENT = { KEEP_ALIVE: false, MAX_SOCKETS: 1000, MAX_FREE_SOCKETS: 256, KEEP_ALIVE_MSECS: 60000 }
+        const Config = Proxyquire(`${src}/lib/config`, { '../../config/default.json': DefaultStub })
+        test.equal(process.env.HTTP_AGENT_MAX_SOCKETS, '1000', 'MAX_SOCKETS wired to env as string')
+        test.equal(process.env.HTTP_AGENT_KEEP_ALIVE, 'false', 'KEEP_ALIVE wired to env as string')
+        test.deepEqual(Config.HTTP_AGENT, DefaultStub.HTTP_AGENT, 'exposes HTTP_AGENT on config')
+      } finally {
+        clearAgentEnv()
+      }
+      test.end()
+    })
+
+    httpAgentTest.test('does not set env vars when HTTP_AGENT is absent', test => {
+      clearAgentEnv()
+      const DefaultStub = Util.clone(Default)
+      DefaultStub.ENDPOINT_SECURITY.JWS.JWS_SIGN = false
+      DefaultStub.HTTP_AGENT = undefined
+      const Config = Proxyquire(`${src}/lib/config`, { '../../config/default.json': DefaultStub })
+      test.equal(process.env.HTTP_AGENT_MAX_SOCKETS, undefined, 'no env var set when HTTP_AGENT absent')
+      test.ok(Config, 'config loads without HTTP_AGENT')
+      test.end()
+    })
+
+    httpAgentTest.test('does not overwrite an explicitly-set HTTP_AGENT_* env var', test => {
+      clearAgentEnv()
+      process.env.HTTP_AGENT_MAX_SOCKETS = '4096'
+      try {
+        const DefaultStub = Util.clone(Default)
+        DefaultStub.ENDPOINT_SECURITY.JWS.JWS_SIGN = false
+        DefaultStub.HTTP_AGENT = { MAX_SOCKETS: 512 }
+        Proxyquire(`${src}/lib/config`, { '../../config/default.json': DefaultStub })
+        test.equal(process.env.HTTP_AGENT_MAX_SOCKETS, '4096', 'explicit env var wins over config value')
+      } finally {
+        clearAgentEnv()
+      }
+      test.end()
+    })
+
+    httpAgentTest.end()
+  })
+
   configTest.end()
 })


### PR DESCRIPTION
**Added HTTP agent configurability**

- Add an `HTTP_AGENT` section to config/default.json (`KEEP_ALIVE`, `MAX_SOCKETS`, `MAX_FREE_SOCKETS`, KEEP_ALIVE_MSECS) to bound the outbound connection pool.
- Bridge those config values into the `HTTP_AGENT_*` env vars consumed by `@mojaloop/central-services-shared` at load.
- Remove the unbounded `axios.defaults.httpAgent = new http.Agent({ keepAlive: true })` override in `src/lib/healthCheck/subServiceHealth.js`, which was clobbering the library's bounded agent.